### PR TITLE
add compatibility with ipython 0.11

### DIFF
--- a/netaddr/tools/netaddr
+++ b/netaddr/tools/netaddr
@@ -15,18 +15,23 @@ from netaddr import *
 from netaddr import IPAddress as IP, IPNetwork as CIDR
 from netaddr import EUI as MAC
 
-try:
-    from IPython.Shell import IPShellEmbed
-except ImportError:
-    sys.stderr.write('IPython (http://ipython.scipy.org/) not found!')
-    sys.exit(1)
-
 argv = sys.argv[1:]
 
 banner = "\nnetaddr shell %s - %s\n" % (netaddr.__version__, __doc__)
 exit_msg = "\nShare and enjoy!"
 rc_override = None
 
-ipshell = IPShellEmbed(argv, banner, exit_msg, rc_override)
+try:
+    try:
+        # ipython >= 0.11
+        from IPython.frontend.terminal.embed import InteractiveShellEmbed
+        ipshell = InteractiveShellEmbed(banner1=banner, exit_msg=exit_msg)
+    except ImportError:
+        # ipython < 0.11
+        from IPython.Shell import IPShellEmbed
+        ipshell = IPShellEmbed(argv, banner, exit_msg, rc_override)
+except ImportError:
+    sys.stderr.write('IPython (http://ipython.scipy.org/) not found!')
+    sys.exit(1)
 
 ipshell()


### PR DESCRIPTION
first try to import 0.11 api if that fails try 0.10

required to work with the new ipython version 0.11 which changes the embedded shell api
