### PR TITLE
Fixed TypeError when comparing BaseIP instances with non-BaseIP objects.

### DIFF
--- a/netaddr/ip/__init__.py
+++ b/netaddr/ip/__init__.py
@@ -75,7 +75,7 @@ class BaseIP(object):
         """
         try:
             return self.key() == other.key()
-        except AttributeError:
+        except (AttributeError, TypeError):
             return NotImplemented
 
     def __ne__(self, other):
@@ -87,7 +87,7 @@ class BaseIP(object):
         """
         try:
             return self.key() != other.key()
-        except AttributeError:
+        except (AttributeError, TypeError):
             return NotImplemented
 
     def __lt__(self, other):
@@ -99,7 +99,7 @@ class BaseIP(object):
         """
         try:
             return self.sort_key() < other.sort_key()
-        except AttributeError:
+        except (AttributeError, TypeError):
             return NotImplemented
 
     def __le__(self, other):
@@ -111,7 +111,7 @@ class BaseIP(object):
         """
         try:
             return self.sort_key() <= other.sort_key()
-        except AttributeError:
+        except (AttributeError, TypeError):
             return NotImplemented
 
     def __gt__(self, other):
@@ -123,7 +123,7 @@ class BaseIP(object):
         """
         try:
             return self.sort_key() > other.sort_key()
-        except AttributeError:
+        except (AttributeError, TypeError):
             return NotImplemented
 
     def __ge__(self, other):
@@ -135,7 +135,7 @@ class BaseIP(object):
         """
         try:
             return self.sort_key() >= other.sort_key()
-        except AttributeError:
+        except (AttributeError, TypeError):
             return NotImplemented
 
     def is_unicast(self):


### PR DESCRIPTION
Hello,

Netaddr crashes when comparing a BaseIP instance with an object that bears a non-callable .key attribute.

This can be trivially fixed by returning NotImplemented when the comparison with other.key() raises a TypeError exception. Here's a proposed implementation of this fix.
