### PR TITLE
IPSet methods use __class__ for new objects

### DIFF
--- a/netaddr/ip/sets.py
+++ b/netaddr/ip/sets.py
@@ -338,7 +338,7 @@ class IPSet(object):
             empty set.
         """
         result = self.intersection(other)
-        if result == IPSet():
+        if result == self.__class__():
             return True
         return False
 
@@ -513,7 +513,7 @@ class IPSet(object):
             cidrs = iprange_to_cidrs(IPAddress(start, 6), IPAddress(end-1, 6))
             cidr_list.extend(cidrs)
 
-        result = IPSet()
+        result = self.__class__()
         # None of these CIDRs can be compacted, so skip that operation.
         result._cidrs = dict.fromkeys(cidr_list, True)
         return result
@@ -554,7 +554,7 @@ class IPSet(object):
             cidrs = iprange_to_cidrs(IPAddress(start, 6), IPAddress(end-1, 6))
             cidr_list.extend(cidrs)
 
-        result = IPSet()
+        result = self.__class__()
         # None of these CIDRs can be compacted, so skip that operation.
         result._cidrs = dict.fromkeys(cidr_list, True)
         return result
@@ -595,7 +595,7 @@ class IPSet(object):
             cidrs = iprange_to_cidrs(IPAddress(start, 6), IPAddress(end-1, 6))
             cidr_list.extend(cidrs)
 
-        result = IPSet()
+        result = self.__class__()
         # None of these CIDRs can be compacted, so skip that operation.
         result._cidrs = dict.fromkeys(cidr_list, True)
         return result


### PR DESCRIPTION
Instead of the hard coded class name, to allow for easier overriding, as you'll get the child class instead.
