### PR TITLE
Added Function to create list of IPRange for non-contiguous IPSet

### DIFF
--- a/netaddr/ip/sets.py
+++ b/netaddr/ip/sets.py
@@ -762,4 +762,5 @@ class IPSet(object):
                     first = x
                 else:
                     ipList.append(IPRange(cidrs[x][0],cidrs[x][-1]))
+        return ipList
 


### PR DESCRIPTION
I have added a function called ipranges to the IPSet object to allow the handling of non-contiguous ip space.
