### PR TITLE
Have return code indicate whether test run was successful

### DIFF
--- a/netaddr/tests/__init__.py
+++ b/netaddr/tests/__init__.py
@@ -65,8 +65,9 @@ def test_suite_all():
 #-----------------------------------------------------------------------------
 def run():
     runner = unittest.TextTestRunner()
-    runner.run(test_suite_all())
+    return runner.run(test_suite_all())
 
 #-----------------------------------------------------------------------------
 if __name__ == "__main__":
-    run()
+    result = run()
+    sys.exit(not result.wasSuccessful())


### PR DESCRIPTION
Right now, running the tests via the tests/**init**.py always returns
0 (success). Have it return a failure code if the tests fail, so it
can be checked by automated systems.
