### PR TITLE
Add mac_unix_expanded format

### DIFF
--- a/netaddr/__init__.py
+++ b/netaddr/__init__.py
@@ -39,8 +39,8 @@ from netaddr.strategy.ipv4 import valid_str as valid_ipv4
 from netaddr.strategy.ipv6 import valid_str as valid_ipv6, ipv6_compact, \
     ipv6_full, ipv6_verbose
 
-from netaddr.strategy.eui48 import mac_eui48, mac_unix, mac_cisco, \
-    mac_bare, mac_pgsql, valid_str as valid_mac
+from netaddr.strategy.eui48 import mac_eui48, mac_unix, mac_unix_expanded, \
+        mac_cisco, mac_bare, mac_pgsql, valid_str as valid_mac
 
 __all__ = [
     #   Constants.
@@ -72,6 +72,7 @@ __all__ = [
 
     #   EUI-48 (MAC) dialect classes.
     'mac_bare', 'mac_cisco', 'mac_eui48', 'mac_pgsql', 'mac_unix',
+    'mac_unix_expanded',
 
     #   Validation functions.
     'valid_ipv4', 'valid_ipv6', 'valid_glob', 'valid_mac',

--- a/netaddr/strategy/eui48.py
+++ b/netaddr/strategy/eui48.py
@@ -78,6 +78,10 @@ class mac_unix(mac_eui48):
     word_fmt  = '%x'
     word_base = 16
 
+class mac_unix_expanded(mac_unix):
+    """A UNIX-style MAC address dialect class with leading zeroes."""
+    word_fmt  = '%.2x'
+
 class mac_cisco(mac_eui48):
     """A Cisco 'triple hextet' MAC address dialect class."""
     word_size = 16

--- a/netaddr/tests/2.x/eui/tutorial.txt
+++ b/netaddr/tests/2.x/eui/tutorial.txt
@@ -100,6 +100,9 @@ EUI('00-1B-77-49-54-FD')
 >>> mac.dialect = mac_unix
 >>> mac
 EUI('0:1b:77:49:54:fd')
+>>> mac.dialect = mac_unix_expanded
+>>> mac
+EUI('00:1b:77:49:54:fd')
 >>> mac.dialect = mac_cisco
 >>> mac
 EUI('001b.7749.54fd')

--- a/netaddr/tests/2.x/strategy/eui48.txt
+++ b/netaddr/tests/2.x/strategy/eui48.txt
@@ -72,6 +72,9 @@ True
 >>> int_to_str(i, mac_unix)
 '0:f:1f:12:e7:33'
 
+>>> int_to_str(i, mac_unix_expanded)
+'00:0f:1f:12:e7:33'
+
 >>> int_to_words(i, mac_unix)
 (0, 15, 31, 18, 231, 51)
 

--- a/netaddr/tests/3.x/eui/tutorial.txt
+++ b/netaddr/tests/3.x/eui/tutorial.txt
@@ -131,6 +131,10 @@ EUI('00-1B-77-49-54-FD')
 >>> mac
 EUI('0:1b:77:49:54:fd')
 
+>>> mac.dialect = mac_unix_expanded
+>>> mac
+EUI('00:1b:77:49:54:fd')
+
 >>> mac.dialect = mac_cisco
 >>> mac
 EUI('001b.7749.54fd')

--- a/netaddr/tests/3.x/strategy/eui48.txt
+++ b/netaddr/tests/3.x/strategy/eui48.txt
@@ -66,6 +66,9 @@ True
 >>> int_to_str(i, mac_unix)
 '0:f:1f:12:e7:33'
 
+>>> int_to_str(i, mac_unix_expanded)
+'00:0f:1f:12:e7:33'
+
 >>> int_to_str(i, mac_cisco)
 '000f.1f12.e733'
 


### PR DESCRIPTION
Most of the utilities use zero-filled representations
for mac address on *nix systems. The existing mac_unix
formatting strategy, however, crops leading zeroes which
may cause different kinds of problems when integrating
several services or software.

This patch adds a mac_unix_expanded formatting strategy which
allows to represent mac addresses as zeros-filled strings.
