### PR TITLE
add property setter for netmask for IPNetwork()

### DIFF
--- a/netaddr/ip/__init__.py
+++ b/netaddr/ip/__init__.py
@@ -1024,6 +1024,19 @@ class IPNetwork(BaseIP, IPListMixin):
         netmask = self._module.max_int ^ self._hostmask_int
         return IPAddress(netmask, self._module.version)
 
+    @netmask.setter
+    def netmask(self, value):
+        """Set the prefixlen using a subnet mask"""
+        ip = IPAddress(value)
+
+        if ip.version != self.version:
+            raise ValueError("IP version mismatch: %s and %s" % (ip, self))
+
+        if not ip.is_netmask():
+            raise ValueError("Invalid subnet mask specified: %s" % str(value))
+
+        self.prefixlen = ip.netmask_bits()
+
     @property
     def _netmask_int(self):
         """Same as self.netmask, but in integer format"""

--- a/netaddr/tests/ip/test_ip_v4.py
+++ b/netaddr/tests/ip/test_ip_v4.py
@@ -509,3 +509,25 @@ def test_rfc3021_subnets():
     # IPv6 must not be affected
     assert IPNetwork('abcd::/127').broadcast is not None
     assert IPNetwork('abcd::/128').broadcast is not None
+
+
+def test_ipnetwork_change_prefixlen():
+    ip = IPNetwork('192.168.0.0/16')
+    assert ip.prefixlen == 16
+    ip.prefixlen = 8
+    assert ip.prefixlen == 8
+
+    ip = IPNetwork('dead:beef::/16')
+    assert ip.prefixlen == 16
+    ip.prefixlen = 64
+    assert ip.prefixlen == 64
+
+
+def test_ipnetwork_change_netmask():
+    ip = IPNetwork('192.168.0.0/16')
+    ip.netmask = '255.0.0.0'
+    assert ip.prefixlen == 8
+
+    ip = IPNetwork('dead:beef::/16')
+    ip.netmask = 'ffff:ffff:ffff:ffff::'
+    assert ip.prefixlen == 64

--- a/tutorials/2.x/ip/tutorial.txt
+++ b/tutorials/2.x/ip/tutorial.txt
@@ -113,6 +113,17 @@ IPNetwork('192.0.2.1/0')
 >>> ip
 IPNetwork('192.0.2.1/23')
 
+The prefix length can also be changed by specifying a subnet mask:
+
+>>> ip = IPNetwork('192.168.1.0/24')
+>>> ip.netmask = '255.255.0.0'
+>>> ip
+IPNetwork('192.168.1.0/16')
+>>> ip = IPNetwork('fe80::dead:beef/64')
+>>> ip.netmask = 'ffff:ffff::'
+>>> ip
+IPNetwork('fe80::dead:beef/32')
+
 There is also a property that lets you access the *true* CIDR address which removes all host bits from the network address based on the CIDR subnet prefix.
 
 >>> ip.cidr


### PR DESCRIPTION
This is a simple solution for #126 (but still unfinished).

```
In [1]: from netaddr.ip import IPNetwork

In [2]: x = IPNetwork('127.0.0.0/16')

In [3]: x.netmask = '255.255.255.0'

In [4]: x
Out[4]: IPNetwork('127.0.0.0/24')

In [5]: x.prefixlen
Out[5]: 24

In [6]: x.netmask
Out[6]: IPAddress('255.255.255.0')
```

Note: `x.netmask` can also be set with the same values as `prefixlen` e.g. `"24" and 24` are valid inputs.

I'll also add some tests and docs.
