### PR TITLE
Stop replacing script shebang

### DIFF
--- a/netaddr/ip/__init__.py
+++ b/netaddr/ip/__init__.py
@@ -1274,7 +1274,7 @@ class IPNetwork(BaseIP, IPListMixin):
         i = 0
         while(i < count):
             subnet = self.__class__('%s/%d' % (base_subnet, prefixlen),
-                self._module.version)
+                False, self._module.version)
             subnet.value += (subnet.size * i)
             subnet.prefixlen = prefixlen
             i += 1

--- a/setup.py
+++ b/setup.py
@@ -177,11 +177,6 @@ def main():
         scripts=['netaddr/tools/netaddr'],
         url='https://github.com/drkjam/netaddr/',
         version=netaddr.__version__,
-        options={
-            'build_scripts': {
-                'executable': '/usr/bin/env python',
-            },
-        },
     )
 
     setup(**setup_options)


### PR DESCRIPTION
These lines, which were added as a fix for #84, have side effects on packaging, e.g. for FreeBSD port, where script shebangs are replaced by correct ones (using either ```python2``` or ```python3``` depending on system settings, while ```python``` may not exist or may point to incorrect python version) before the build. Because of these lines, during the build they are replaced with an incorrect shebang again.