### PR TITLE
Add format function to EUI

### DIFF
--- a/netaddr/eui/__init__.py
+++ b/netaddr/eui/__init__.py
@@ -455,17 +455,20 @@ class EUI(BaseIdentifier):
     def _get_dialect(self):
         return self._dialect
 
-    def _set_dialect(self, value):
+    def _validate_dialect(self, value):
         if value is None:
             if self._module is _eui64:
-                self._dialect = eui64_base
+               return eui64_base
             else:
-                self._dialect = mac_eui48
+                return mac_eui48
         else:
             if hasattr(value, 'word_size') and hasattr(value, 'word_fmt'):
-                self._dialect = value
+                return value
             else:
                 raise TypeError('custom dialects should subclass mac_eui48!')
+
+    def _set_dialect(self, value):
+        self._dialect = self._validate_dialect(value)
 
     dialect = property(_get_dialect, _set_dialect, None,
         "a Python class providing support for the interpretation of "
@@ -720,6 +723,19 @@ class EUI(BaseIdentifier):
             data['IAB'] = self.iab.registration()
 
         return DictDotLookup(data)
+
+    def format(self, dialect=None):
+        """
+        Format the EUI into the representational format according to the given
+        dialect
+
+        :param dialect: the mac_* dialect defining the formatting of EUI-48 \
+            (MAC) addresses.
+
+        :return: EUI in representational format according to the given dialect
+        """
+        validated_dialect = self._validate_dialect(dialect)
+        return self._module.int_to_str(self._value, validated_dialect)
 
     def __str__(self):
         """:return: EUI in representational format"""

--- a/netaddr/ip/__init__.py
+++ b/netaddr/ip/__init__.py
@@ -1274,7 +1274,7 @@ class IPNetwork(BaseIP, IPListMixin):
         i = 0
         while(i < count):
             subnet = self.__class__('%s/%d' % (base_subnet, prefixlen),
-                self._module.version)
+                False, self._module.version)
             subnet.value += (subnet.size * i)
             subnet.prefixlen = prefixlen
             i += 1

--- a/netaddr/tests/eui/test_eui.py
+++ b/netaddr/tests/eui/test_eui.py
@@ -93,6 +93,13 @@ def test_eui_dialect_property_assignment():
     assert str(mac) == '001b77:4954fd'
 
 
+def test_eui_format():
+    mac = EUI('00-1B-77-49-54-FD')
+    assert mac.format() == '00-1B-77-49-54-FD'
+    assert mac.format(mac_pgsql) == '001b77:4954fd'
+    assert mac.format(mac_unix_expanded) == '00:1b:77:49:54:fd'
+
+
 def test_eui_custom_dialect():
     class mac_custom(mac_unix):
         word_fmt = '%.2X'


### PR DESCRIPTION
This function allows to format an EUI into any dialect, regardless of
the dialect given during construction. This allows clients to generate a
representation of the EUI according to the needed format without
modifying the object.