### PR TITLE
fix bug that broadcast is None when netmast is 31 or 32

### DIFF
--- a/netaddr/ip/__init__.py
+++ b/netaddr/ip/__init__.py
@@ -996,10 +996,7 @@ class IPNetwork(BaseIP, IPListMixin):
     @property
     def broadcast(self):
         """The broadcast address of this `IPNetwork` object"""
-        if self._module.version == 4 and (self._module.width - self._prefixlen) <= 1:
-            return None
-        else:
-            return IPAddress(self._value | self._hostmask_int, self._module.version)
+        return IPAddress(self._value | self._hostmask_int, self._module.version)
 
     @property
     def first(self):


### PR DESCRIPTION
if network is 3.3.3.244/31 or 3.3.3.244/32 then 
    broadcast is None
end
it seem unfriendly 