### PR TITLE
Added __bytes__ implementation for intuitive usage

### DIFF
--- a/netaddr/ip/__init__.py
+++ b/netaddr/ip/__init__.py
@@ -499,6 +499,14 @@ class IPAddress(BaseIP):
         #   Python 3.x
         return self._value
 
+    def __bytes__(self):
+        """ 
+        :return: a bytes object equivalent to this IP address. In network
+        byte order, big-endian.
+        """
+        #   Python 3.x
+        return self._value.to_bytes(self._module.width//8, 'big')
+
     def bits(self, word_sep=None):
         """
         :param word_sep: (optional) the separator to insert between words.


### PR DESCRIPTION
When constructing a bytes object from an IPAddress object in Python3
it seems intuitive for the result to be a byte string of the IP address
words.

e.g.

```Python
>>> bytes(IPAddress('1.1.1.1'))
b'\x01\x01\x01\x01'
```

Instead, `__index__` is called and perhaps tens of millions of bytes are allocated,
which can even crash unaware users. This can be surprising and unexpected.

```Python
>>> bytes(IPAddress('1.1.1.1'))
b'\x00\x00\x00\x00\x00\x00\x00\x00... # did you really expect this?
```

In addition, having bytes(IPAddress(...)) yield a byte string is far
more readable, idiomatic, and is highly applicable, such as with
storing IPAddresses in data bases, without using the heinous one-shot
socket/struct import.

Implementing `__bytes__`  allows for high readability in this use case.