### PR TITLE
Two fixes

### DIFF
--- a/netaddr/eui/__init__.py
+++ b/netaddr/eui/__init__.py
@@ -85,9 +85,9 @@ class OUI(BaseIdentifier):
             if 0 <= oui <= 0xffffff:
                 self._value = oui
             else:
-                raise ValueError('OUI int outside expected range: %r' % oui)
+                raise ValueError('OUI int outside expected range: %r' % (oui,))
         else:
-            raise TypeError('unexpected OUI format: %r' % oui)
+            raise TypeError('unexpected OUI format: %r' % (oui,))
 
         #   Discover offsets.
         if self._value in ieee.OUI_INDEX:
@@ -98,7 +98,7 @@ class OUI(BaseIdentifier):
                 self._parse_data(data, offset, size)
             fh.close()
         else:
-            raise NotRegisteredError('OUI %r not registered!' % oui)
+            raise NotRegisteredError('OUI %r not registered!' % (oui,))
 
     def __eq__(self, other):
         if not isinstance(other, OUI):
@@ -252,7 +252,7 @@ class IAB(BaseIdentifier):
             iab_int, user_int = self.split_iab_mac(iab, strict=strict)
             self._value = iab_int
         else:
-            raise TypeError('unexpected IAB format: %r!' % iab)
+            raise TypeError('unexpected IAB format: %r!' % (iab,))
 
         #   Discover offsets.
         if self._value in ieee.IAB_INDEX:
@@ -265,7 +265,7 @@ class IAB(BaseIdentifier):
             self._parse_data(data, offset, size)
             fh.close()
         else:
-            raise NotRegisteredError('IAB %r not unregistered!' % iab)
+            raise NotRegisteredError('IAB %r not unregistered!' % (iab,))
 
     def __eq__(self, other):
         if not isinstance(other, IAB):
@@ -408,7 +408,7 @@ class EUI(BaseIdentifier):
             self._module = _eui64
         else:
             raise ValueError('unpickling failed for object state: %s' \
-                % str(state))
+                % (state,))
 
         self.dialect = dialect
 
@@ -434,7 +434,7 @@ class EUI(BaseIdentifier):
 
             if self._module is None:
                 raise AddrFormatError('failed to detect EUI version: %r'
-                    % value)
+                    % (value,))
         else:
             #   EUI version is explicit.
             if _is_str(value):
@@ -447,7 +447,7 @@ class EUI(BaseIdentifier):
                 if 0 <= int(value) <= self._module.max_int:
                     self._value = int(value)
                 else:
-                    raise AddrFormatError('bad address format: %r' % value)
+                    raise AddrFormatError('bad address format: %r' % (value,))
 
     value = property(_get_value, _set_value, None,
         'a positive integer representing the value of this EUI indentifier.')
@@ -522,7 +522,7 @@ class EUI(BaseIdentifier):
             words = self._module.int_to_words(self._value, self._dialect)
             return [words[i] for i in range(*idx.indices(len(words)))]
         else:
-            raise TypeError('unsupported type %r!' % idx)
+            raise TypeError('unsupported type %r!' % (idx,))
 
     def __setitem__(self, idx, value):
         """Set the value of the word referenced by index in this address"""
@@ -534,7 +534,7 @@ class EUI(BaseIdentifier):
             raise TypeError('index not an integer!')
 
         if not 0 <= idx <= (self._dialect.num_words - 1):
-            raise IndexError('index %d outside address type boundary!' % idx)
+            raise IndexError('index %d outside address type boundary!' % (idx,))
 
         if not _is_int(value):
             raise TypeError('value not an integer!')

--- a/netaddr/fbsocket.py
+++ b/netaddr/fbsocket.py
@@ -18,7 +18,7 @@ def inet_ntoa(packed_ip):
     Convert an IP address from 32-bit packed binary format to string format.
     """
     if not _is_str(packed_ip):
-        raise TypeError('string type expected, not %s' % str(type(packed_ip)))
+        raise TypeError('string type expected, not %s' % type(packed_ip))
 
     if len(packed_ip) != 4:
         raise ValueError('invalid length of packed IP address string')

--- a/netaddr/ip/__init__.py
+++ b/netaddr/ip/__init__.py
@@ -1258,7 +1258,7 @@ class IPNetwork(BaseIP, IPListMixin):
 
         if not self.prefixlen <= prefixlen:
             #   Don't return anything.
-            raise StopIteration
+            return
 
         #   Calculate number of subnets to be returned.
         width = self._module.width

--- a/netaddr/ip/__init__.py
+++ b/netaddr/ip/__init__.py
@@ -316,7 +316,7 @@ class IPAddress(BaseIP):
                     if 0 <= int(addr) <= self._module.max_int:
                         self._value = int(addr)
                     else:
-                        raise AddrFormatError('bad address format: %r' % addr)
+                        raise AddrFormatError('bad address format: %r' % (addr,))
 
     def __getstate__(self):
         """:returns: Pickled state of an `IPAddress` object."""
@@ -935,7 +935,7 @@ class IPNetwork(BaseIP, IPListMixin):
                     pass
 
                 if value is None:
-                    raise AddrFormatError('invalid IPNetwork %s' % addr)
+                    raise AddrFormatError('invalid IPNetwork %s' % (addr,))
 
         self._value = value
         self._prefixlen = prefixlen
@@ -960,13 +960,13 @@ class IPNetwork(BaseIP, IPListMixin):
             self._module = _ipv6
         else:
             raise ValueError('unpickling failed for object state %s' \
-                % str(state))
+                % (state,))
 
         if 0 <= prefixlen <= self._module.width:
             self._prefixlen = prefixlen
         else:
             raise ValueError('unpickling failed for object state %s' \
-                % str(state))
+                % (state,))
 
     def _set_prefixlen(self, value):
         if not isinstance(value, _int_type):
@@ -1505,7 +1505,7 @@ def cidr_abbrev_to_verbose(abbrev_cidr):
             try:
                 if not 0 <= int(prefix) <= 32:
                     raise ValueError('prefixlen in address %r out of range' \
-                        ' for IPv4!' % abbrev_cidr)
+                        ' for IPv4!' % (abbrev_cidr,))
             except ValueError:
                 return abbrev_cidr
         else:
@@ -1783,7 +1783,7 @@ def smallest_matching_cidr(ip, cidrs):
 
     if not hasattr(cidrs, '__iter__'):
         raise TypeError('IP address/subnet sequence expected, not %r!'
-            % cidrs)
+            % (cidrs,))
 
     ip = IPAddress(ip)
     for cidr in sorted([IPNetwork(cidr) for cidr in cidrs]):
@@ -1812,7 +1812,7 @@ def largest_matching_cidr(ip, cidrs):
 
     if not hasattr(cidrs, '__iter__'):
         raise TypeError('IP address/subnet sequence expected, not %r!'
-            % cidrs)
+            % (cidrs,))
 
     ip = IPAddress(ip)
     for cidr in sorted([IPNetwork(cidr) for cidr in cidrs]):
@@ -1839,7 +1839,7 @@ def all_matching_cidrs(ip, cidrs):
 
     if not hasattr(cidrs, '__iter__'):
         raise TypeError('IP address/subnet sequence expected, not %r!'
-            % cidrs)
+            % (cidrs,))
 
     ip = IPAddress(ip)
     for cidr in sorted([IPNetwork(cidr) for cidr in cidrs]):

--- a/netaddr/ip/glob.py
+++ b/netaddr/ip/glob.py
@@ -77,7 +77,7 @@ def glob_to_iptuple(ipglob):
     :return: a tuple contain lower and upper bound IP objects.
     """
     if not valid_glob(ipglob):
-        raise AddrFormatError('not a recognised IP glob range: %r!' % ipglob)
+        raise AddrFormatError('not a recognised IP glob range: %r!' % (ipglob,))
 
     start_tokens = []
     end_tokens = []
@@ -107,7 +107,7 @@ def glob_to_iprange(ipglob):
     :return: an IPRange object.
     """
     if not valid_glob(ipglob):
-        raise AddrFormatError('not a recognised IP glob range: %r!' % ipglob)
+        raise AddrFormatError('not a recognised IP glob range: %r!' % (ipglob,))
 
     start_tokens = []
     end_tokens = []

--- a/netaddr/ip/iana.py
+++ b/netaddr/ip/iana.py
@@ -407,7 +407,7 @@ def _within_bounds(ip, ip_range):
         #   IP address.
         return ip == ip_range
 
-    raise Exception('Unsupported IP range or address: %r!' % ip_range)
+    raise Exception('Unsupported IP range or address: %r!' % (ip_range,))
 
 
 def query(ip_addr):

--- a/netaddr/ip/nmap.py
+++ b/netaddr/ip/nmap.py
@@ -31,15 +31,15 @@ def _nmap_octet_target_values(spec):
             low = int(left)
             high = int(right)
             if not ((0 <= low <= 255) and (0 <= high <= 255)):
-                raise ValueError('octet value overflow for spec %s!' % spec)
+                raise ValueError('octet value overflow for spec %s!' % (spec,))
             if low > high:
-                raise ValueError('left side of hyphen must be <= right %r' % element)
+                raise ValueError('left side of hyphen must be <= right %r' % (element,))
             for octet in _iter_range(low, high + 1):
                 values.add(octet)
         else:
             octet = int(element)
             if not (0 <= octet <= 255):
-                raise ValueError('octet value overflow for spec %s!' % spec)
+                raise ValueError('octet value overflow for spec %s!' % (spec,))
             values.add(octet)
 
     return sorted(values)
@@ -57,7 +57,7 @@ def _generate_nmap_octet_ranges(nmap_target_spec):
     tokens = nmap_target_spec.split('.')
 
     if len(tokens) != 4:
-        raise AddrFormatError('invalid nmap range: %s' % nmap_target_spec)
+        raise AddrFormatError('invalid nmap range: %s' % (nmap_target_spec,))
 
     return (_nmap_octet_target_values(tokens[0]),
             _nmap_octet_target_values(tokens[1]),
@@ -69,7 +69,7 @@ def _parse_nmap_target_spec(target_spec):
     if '/' in target_spec:
         _, prefix = target_spec.split('/', 1)
         if not (0 < int(prefix) < 33):
-            raise AddrFormatError('CIDR prefix expected, not %s' % prefix)
+            raise AddrFormatError('CIDR prefix expected, not %s' % (prefix,))
         net = IPNetwork(target_spec)
         if net.version != 4:
             raise AddrFormatError('CIDR only support for IPv4!')

--- a/netaddr/ip/rfc1924.py
+++ b/netaddr/ip/rfc1924.py
@@ -49,7 +49,7 @@ def base85_to_ipv6(addr):
     tokens = list(addr)
 
     if len(tokens) != 20:
-        raise AddrFormatError('Invalid base 85 IPv6 address: %r' % addr)
+        raise AddrFormatError('Invalid base 85 IPv6 address: %r' % (addr,))
 
     result = 0
     for i, num in enumerate(reversed(tokens)):

--- a/netaddr/strategy/__init__.py
+++ b/netaddr/strategy/__init__.py
@@ -95,7 +95,7 @@ def words_to_int(words, word_size, num_words):
         by word sequence.
     """
     if not valid_words(words, word_size, num_words):
-        raise ValueError('invalid integer word sequence: %r!' % words)
+        raise ValueError('invalid integer word sequence: %r!' % (words,))
 
     int_val = 0
     for i, num in enumerate(reversed(words)):
@@ -152,7 +152,7 @@ def bits_to_int(bits, width, word_sep=''):
         by network address in readable binary form.
     """
     if not valid_bits(bits, width, word_sep):
-        raise ValueError('invalid readable binary string: %r!' % bits)
+        raise ValueError('invalid readable binary string: %r!' % (bits,))
 
     if word_sep != '':
         bits = bits.replace(word_sep, '')
@@ -189,7 +189,7 @@ def int_to_bits(int_val, word_size, num_words, word_sep=''):
     if word_sep is not '':
         #   Check custom separator.
         if not _is_str(word_sep):
-            raise ValueError('word separator is not a string: %r!' % word_sep)
+            raise ValueError('word separator is not a string: %r!' % (word_sep,))
 
     return word_sep.join(bit_words)
 
@@ -252,7 +252,7 @@ def int_to_bin(int_val, width):
         bin_val = '0b' + _re.sub(r'^[0]+([01]+)$', r'\1', ''.join(bin_tokens))
 
     if len(bin_val[2:]) > width:
-        raise IndexError('binary string out of bounds: %s!' % bin_val)
+        raise IndexError('binary string out of bounds: %s!' % (bin_val,))
 
     return bin_val
 
@@ -268,6 +268,6 @@ def bin_to_int(bin_val, width):
         by Python binary string format.
     """
     if not valid_bin(bin_val, width):
-        raise ValueError('not a valid Python binary string: %r!' % bin_val)
+        raise ValueError('not a valid Python binary string: %r!' % (bin_val,))
 
     return int(bin_val.replace('0b', ''), 2)

--- a/netaddr/strategy/eui48.py
+++ b/netaddr/strategy/eui48.py
@@ -173,9 +173,9 @@ def str_to_int(addr):
                     words = (match_result[0],)
                 break
         if not found_match:
-            raise AddrFormatError('%r is not a supported MAC format!' % addr)
+            raise AddrFormatError('%r is not a supported MAC format!' % (addr,))
     else:
-        raise TypeError('%r is not str() or unicode()!' % addr)
+        raise TypeError('%r is not str() or unicode()!' % (addr,))
 
     int_val = None
 
@@ -192,7 +192,7 @@ def str_to_int(addr):
         #   12 bytes (bare, no delimiters)
         int_val = int('%012x' % int(words[0], 16), 16)
     else:
-        raise AddrFormatError('unexpected word count in MAC address %r!' % addr)
+        raise AddrFormatError('unexpected word count in MAC address %r!' % (addr,))
 
     return int_val
 

--- a/netaddr/strategy/eui64.py
+++ b/netaddr/strategy/eui64.py
@@ -153,7 +153,7 @@ def str_to_int(addr):
         if not words:
             raise TypeError
     except TypeError:
-        raise AddrFormatError('invalid IEEE EUI-64 identifier: %r!' % addr)
+        raise AddrFormatError('invalid IEEE EUI-64 identifier: %r!' % (addr,))
 
     if isinstance(words, tuple):
         pass

--- a/netaddr/strategy/ipv4.py
+++ b/netaddr/strategy/ipv4.py
@@ -126,7 +126,7 @@ def str_to_int(addr, flags=0):
         else:
             return _struct.unpack('>I', _inet_aton(addr))[0]
     except Exception:
-        raise AddrFormatError('%r is not a valid IPv4 address string!' % addr)
+        raise AddrFormatError('%r is not a valid IPv4 address string!' % (addr,))
 
 
 def int_to_str(int_val, dialect=None):
@@ -145,7 +145,7 @@ def int_to_str(int_val, dialect=None):
             (int_val >> 8) & 0xff,
             int_val & 0xff)
     else:
-        raise ValueError('%r is not a valid 32-bit unsigned integer!' % int_val)
+        raise ValueError('%r is not a valid 32-bit unsigned integer!' % (int_val,))
 
 
 def int_to_arpa(int_val):
@@ -195,7 +195,7 @@ def int_to_words(int_val):
     """
     if not 0 <= int_val <= max_int:
         raise ValueError('%r is not a valid integer value supported by'
-                         'this address type!' % int_val)
+                         'this address type!' % (int_val,))
     return ( int_val >> 24,
             (int_val >> 16) & 0xff,
             (int_val >>  8) & 0xff,
@@ -210,7 +210,7 @@ def words_to_int(words):
         by word (octet) sequence.
     """
     if not valid_words(words):
-        raise ValueError('%r is not a valid octet list for an IPv4 address!' % words)
+        raise ValueError('%r is not a valid octet list for an IPv4 address!' % (words,))
     return _struct.unpack('>I', _struct.pack('4B', *words))[0]
 
 

--- a/netaddr/strategy/ipv6.py
+++ b/netaddr/strategy/ipv6.py
@@ -139,7 +139,7 @@ def str_to_int(addr, flags=0):
         packed_int = _inet_pton(AF_INET6, addr)
         return packed_to_int(packed_int)
     except Exception:
-        raise AddrFormatError('%r is not a valid IPv6 address string!' % addr)
+        raise AddrFormatError('%r is not a valid IPv6 address string!' % (addr,))
 
 
 def int_to_str(int_val, dialect=None):
@@ -167,7 +167,7 @@ def int_to_str(int_val, dialect=None):
             tokens = [dialect.word_fmt % word for word in words]
             addr = word_sep.join(tokens)
     except Exception:
-        raise ValueError('%r is not a valid 128-bit unsigned integer!' % int_val)
+        raise ValueError('%r is not a valid 128-bit unsigned integer!' % (int_val,))
 
     return addr
 


### PR DESCRIPTION
The first patch fixes a test regression on Python 3.7+.

The second repairs unprintable error messages when the parameter in question is a tuple or list. I noticed this when a bug in my code called IPNetwork((22,large_number)) instead of vice versa.