### PR TITLE
Fix warning of using `is not` for string compare

### DIFF
--- a/netaddr/strategy/__init__.py
+++ b/netaddr/strategy/__init__.py
@@ -186,7 +186,7 @@ def int_to_bits(int_val, word_size, num_words, word_sep=''):
         bits = ('0' * word_size + bit_str)[-word_size:]
         bit_words.append(bits)
 
-    if word_sep is not '':
+    if word_sep != '':
         #   Check custom separator.
         if not _is_str(word_sep):
             raise ValueError('word separator is not a string: %r!' % word_sep)


### PR DESCRIPTION
Fix the following warning in python3.8
```
/usr/local/lib/python3.8/site-packages/netaddr-0.7.19-py3.8.egg/netaddr/strategy/__init__.py:189: SyntaxWarning: "is not" with a literal. Did you mean "!="?
  if word_sep is not '':
```