### PR TITLE
Support weak references

### DIFF
--- a/netaddr/eui/__init__.py
+++ b/netaddr/eui/__init__.py
@@ -18,7 +18,7 @@ from netaddr.compat import _importlib_resources, _is_int, _is_str
 
 class BaseIdentifier(object):
     """Base class for all IEEE identifiers."""
-    __slots__ = ('_value',)
+    __slots__ = ('_value', '__weakref__')
 
     def __init__(self):
         self._value = None

--- a/netaddr/ip/__init__.py
+++ b/netaddr/ip/__init__.py
@@ -22,7 +22,7 @@ class BaseIP(object):
     related subclasses.
 
     """
-    __slots__ = ('_value', '_module')
+    __slots__ = ('_value', '_module', '__weakref__')
 
     def __init__(self):
         """Constructor."""

--- a/netaddr/ip/sets.py
+++ b/netaddr/ip/sets.py
@@ -88,7 +88,7 @@ class IPSet(object):
     subnets.
 
     """
-    __slots__ = ('_cidrs',)
+    __slots__ = ('_cidrs', '__weakref__')
 
     def __init__(self, iterable=None, flags=0):
         """


### PR DESCRIPTION
Previously attempting to create a weak reference to an IPAddress object
for example resulted with

    cannot create weak reference to 'IPAddress' object

because if __slots__ is present it needs to contain __weakref__ in order
for weak references to work.

Fixes GH-161.