### PR TITLE
Removing legacy/nonstandard validations for MAC addresses

### DIFF
--- a/netaddr/strategy/eui48.py
+++ b/netaddr/strategy/eui48.py
@@ -112,23 +112,23 @@ DEFAULT_DIALECT = mac_eui48
 
 #-----------------------------------------------------------------------------
 #: Regular expressions to match all supported MAC address formats.
+
 RE_MAC_FORMATS = (
     #   2 bytes x 6 (UNIX, Windows, EUI-48)
-    '^' + ':'.join(['([0-9A-F]{1,2})'] * 6) + '$',
-    '^' + '-'.join(['([0-9A-F]{1,2})'] * 6) + '$',
+    '^' + ':'.join(['([0-9A-F]{2})'] * 6) + '$',
+    '^' + '-'.join(['([0-9A-F]{2})'] * 6) + '$',
 
     #   4 bytes x 3 (Cisco)
-    '^' + ':'.join(['([0-9A-F]{1,4})'] * 3) + '$',
-    '^' + '-'.join(['([0-9A-F]{1,4})'] * 3) + '$',
-    '^' + r'\.'.join(['([0-9A-F]{1,4})'] * 3) + '$',
+    '^' + ':'.join(['([0-9A-F]{4})'] * 3) + '$',
+    '^' + '-'.join(['([0-9A-F]{4})'] * 3) + '$',
+    '^' + r'\.'.join(['([0-9A-F]{4})'] * 3) + '$',
 
     #   6 bytes x 2 (PostgreSQL)
-    '^' + '-'.join(['([0-9A-F]{5,6})'] * 2) + '$',
-    '^' + ':'.join(['([0-9A-F]{5,6})'] * 2) + '$',
+    '^' + '-'.join(['([0-9A-F]{6})'] * 2) + '$',
+    '^' + ':'.join(['([0-9A-F]{6})'] * 2) + '$',
 
     #   12 bytes (bare, no delimiters)
     '^(' + ''.join(['[0-9A-F]'] * 12) + ')$',
-    '^(' + ''.join(['[0-9A-F]'] * 11) + ')$',
 )
 #   For efficiency, each string regexp converted in place to its compiled
 #   counterpart.


### PR DESCRIPTION
Currently, MAC validations accept non-standard MACs that drop
leading digits.  I cannot find documentation from any mentioned
manufacturer that currently accepts these non-standard MACs.

Any non-standard MAC should be validated by a separate routine, or
we're not validating MAC addresses.

References
==========
Cisco:
https://www.ciscopress.com/articles/article.asp?p=3089352&seqNum=5

"When using hexadecimal, leading zeros are always displayed to
complete the 8-bit representation. For example, in Figure 7-6,
the binary value 0000 1010 is shown to be 0A in hexadecimal."

Postgres:
https://www.postgresql.org/docs/9.1/datatype-net-types.html

All examples are 12 hex digits

IETF:
I can't find a single RFC dropping leading zeroes.

IEEE:
I don't have access to the actual EUI-48 spec, but I see nothing
indicating that anyone drops the zeroes.