### PR TITLE
Introduced pyproject.toml.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,3 @@
+[build-system]
+requires = ["setuptools>=30.3.0", "wheel"]
+build-backend = "setuptools.build_meta"


### PR DESCRIPTION
The benefits of pyproject.toml are that it allows the package building be initiated by a PEP 517 build frontend, such as build, which is a recommended and unified (any build backend supporting pep517 (setuptools, flit, poetry) can be executed by a simple and the same command python3 -m build -nwx . (and in case of setup.cfg-only projects, the only way is PEP 517 frontend, since there is no setup.py one can execute), which is very convenient especially for automated scripts, like CI) tool for it.