### PR TITLE
Improve loading time of IEEE data structures

### DIFF
--- a/netaddr/eui/ieee.py
+++ b/netaddr/eui/ieee.py
@@ -271,7 +271,7 @@ def create_indices():
 def load_index(index, fp):
     """Load index from file into index data structure."""
     try:
-        for row in _csv.reader([x.decode('UTF-8') for x in fp]):
+        for row in _csv.reader(fp):
             (key, offset, size) = [int(_) for _ in row]
             index.setdefault(key, [])
             index[key].append((offset, size))
@@ -281,8 +281,8 @@ def load_index(index, fp):
 
 def load_indices():
     """Load OUI and IAB lookup indices into memory"""
-    load_index(OUI_INDEX, _importlib_resources.open_binary(__package__, 'oui.idx'))
-    load_index(IAB_INDEX, _importlib_resources.open_binary(__package__, 'iab.idx'))
+    load_index(OUI_INDEX, _importlib_resources.open_text(__package__, 'oui.idx'))
+    load_index(IAB_INDEX, _importlib_resources.open_text(__package__, 'iab.idx'))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
With python3.9 and below, loading `from netaddr.eui import ieee` will take around 0.5s to run
This change lower the runtime to around 0.07s by only reading the indices files as text


before the fix
```
$ time python3.9 -c 'from netaddr.eui import ieee'

real	0m0.465s
user	0m0.257s
sys	0m0.208s
```

after the fix
```
$ time python3.9 -c 'from netaddr.eui import ieee'

real	0m0.076s
user	0m0.076s
sys	0m0.000s
```

In python3.10 there was some work done to improve importlib that cause the loading time to be somewhere around 0.07s before the fix
 