### PR TITLE
Fixup legacy IPv4 conversion

### DIFF
--- a/netaddr/strategy/ipv4.py
+++ b/netaddr/strategy/ipv4.py
@@ -266,9 +266,14 @@ def expand_partial_address(addr):
         except ValueError:
             raise error
 
-        if 1 <= len(tokens) <= 4:
-            for i in range(4 - len(tokens)):
-                tokens.append('0')
+        if len(tokens) == 1:
+            tokens = ['0', '0', '0', tokens[0]]
+        elif len(tokens) == 2:
+            tokens = [tokens[0], '0', '0', tokens[1]]
+        elif len(tokens) == 3:
+            tokens = [tokens[0], tokens[1], '0', tokens[2]]
+        elif len(tokens) == 4:
+            pass
         else:
             raise error
 

--- a/netaddr/tests/ip/test_old_specs.py
+++ b/netaddr/tests/ip/test_old_specs.py
@@ -276,6 +276,6 @@ def test_cidr_abbrev_to_verbose_invalid_prefixlen():
 
 
 def test_expand_partial_address():
-    assert expand_partial_address('10') == '10.0.0.0'
-    assert expand_partial_address('10.1') == '10.1.0.0'
-    assert expand_partial_address('192.168.1') == '192.168.1.0'
+    assert expand_partial_address('10') == '0.0.0.10'
+    assert expand_partial_address('10.1') == '10.0.0.1'
+    assert expand_partial_address('192.168.1') == '192.168.0.1'


### PR DESCRIPTION
Before this commit, we had this erroneous condition:

    >>> netaddr.IPNetwork('1.1/24')
    IPNetwork('1.1.0.0/24')

Correctly place `0` octets depending on how many octets we're given.
This should fix the above to:

    >>> netaddr.IPNetwork('1.1/24')
    IPNetwork('1.0.0.1/24')

Obtained proper token placement by empirical testing:

    $ ping -c 1 -i 0.2 -W 0.2 1
    PING 1 (0.0.0.1) 56(84) bytes of data.

    --- 1 ping statistics ---
    1 packets transmitted, 0 received, 100% packet loss, time 0ms

    $ ping -c 1 -i 0.2 -W 0.2 1.1
    PING 1.1 (1.0.0.1) 56(84) bytes of data.
    64 bytes from 1.0.0.1: icmp_seq=1 ttl=59 time=4.48 ms

    --- 1.1 ping statistics ---
    1 packets transmitted, 1 received, 0% packet loss, time 0ms
    rtt min/avg/max/mdev = 4.476/4.476/4.476/0.000 ms
    $ ping -c 1 -i 0.2 -W 0.2 1.1.1
    PING 1.1.1 (1.1.0.1) 56(84) bytes of data.

    --- 1.1.1 ping statistics ---
    1 packets transmitted, 0 received, 100% packet loss, time 0ms

    $ ping -c 1 -i 0.2 -W 0.2 1.1.1.1
    PING 1.1.1.1 (1.1.1.1) 56(84) bytes of data.
    64 bytes from 1.1.1.1: icmp_seq=1 ttl=59 time=4.44 ms

    --- 1.1.1.1 ping statistics ---
    1 packets transmitted, 1 received, 0% packet loss, time 0ms
    rtt min/avg/max/mdev = 4.443/4.443/4.443/0.000 ms