### PR TITLE
Run CI with more Python versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,9 @@ jobs:
         # Not all Python versions are available in the latest Ubuntu environments
         # so pin this to 20.04.
         os: [ubuntu-20.04, macos-latest, windows-latest]
-        # At the time of writing this Python 3.12 is not released yet.
-        # Adding it just the same do tect potential incompatibilities early.
         python-version: [
-          3.5, 3.6, 3.7, 3.8, 3.9, "3.10", 3.11, 3.12,
-          pypy2, pypy3.7, pypy3.8, pypy3.9, pypy3.10,
+          3.5, 3.6, 3.7, 3.8, 3.9, "3.10", 3.11,
+          pypy2.7, pypy3.7, pypy3.8, pypy3.9, pypy3.10,
         ]
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
         # Adding it just the same do tect potential incompatibilities early.
         python-version: [
           3.5, 3.6, 3.7, 3.8, 3.9, "3.10", 3.11, 3.12,
-          pypy2, pypy3.7, pypy3.8, pypy3.9, pypy3.10, pypy3.11,
+          pypy2, pypy3.7, pypy3.8, pypy3.9, pypy3.10,
         ]
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,9 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, pypy2, pypy3]
+        # At the time of writing this Python 3.12 is not released yet.
+        # Adding it just the same do tect potential incompatibilities early.
+        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, 3.9, "3.10", 3.11, 3.12, pypy2, pypy3]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
To ensure that we're compatible, without the CI running these versions we don't know.