### PR TITLE
Use the latest setup-python GitHub Action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies


### PR DESCRIPTION
I just tried to kick off a CI process after not running it for a while and it's unable to install various Python versions it should be able to install.

I think this should help for at least some of that.

[1] https://github.com/netaddr/netaddr/actions/runs/6191195608/job/16808994853?pr=256