### PR TITLE
Pin the Ubuntu CI runner to version 20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest, windows-latest]
+        # Not all Python versions are available in the latest Ubuntu environments
+        # so pin this to 20.04.
+        os: [ubuntu-20.04, macos-latest, windows-latest]
         python-version: [2.7, 3.5, 3.6, 3.7, 3.8, pypy2, pypy3]
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
Not all Python versions are available on 22.04[1] and our CI is currently not working because of that.

[1] https://github.com/actions/setup-python/issues/544#issuecomment-1324999753