### PR TITLE
Get the CI running again

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,11 @@ jobs:
         # Not all Python versions are available in the latest Ubuntu environments
         # so pin this to 20.04.
         os: [ubuntu-20.04, macos-latest, windows-latest]
-        python-version: [2.7, 3.5, 3.6, 3.7, 3.8, pypy2, pypy3]
+        python-version: [3.5, 3.6, 3.7, 3.8, pypy2.7, pypy3.6]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
         # Not all Python versions are available in the latest Ubuntu environments
         # so pin this to 20.04.
         os: [ubuntu-20.04, macos-latest, windows-latest]
-        python-version: [3.5, 3.6, 3.7, 3.8, pypy2.7, pypy3.6]
+        python-version: [3.5, 3.6, 3.7, 3.8, pypy2.7, pypy3.7]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}


### PR DESCRIPTION
It's currently failing because:

* Python 2.7 is no longer supported[1]
* setup-python v2 can't find PyPy3.6 on Mac, I think upgrading to v4 will help

Upgrading setup-python to v4 requires us to change how to refer to PyPy – we have to specify the actual version now.

[1] https://github.com/actions/setup-python/issues/672