### PR TITLE
Stop running CI twice in PRs made from this repository

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 
-on: [push, pull_request]
+on: 
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   build:


### PR DESCRIPTION
When you go to [1] for example you'll see we have twice as many CI jobs compared to what we expect (36 instead of 18).

Let's only run "push" jobs on master.

[1] https://github.com/netaddr/netaddr/pull/260