### PR TITLE
Re-land: Handle RFC 6164 IPv6 addresses

### DIFF
--- a/netaddr/tests/ip/test_ip_v4.py
+++ b/netaddr/tests/ip/test_ip_v4.py
@@ -260,8 +260,6 @@ def test_iterhosts_v4():
         IPAddress('192.168.0.1'),
     ]
 
-    assert list(IPNetwork("1234::/128")) == [IPAddress('1234::')]
-    assert list(IPNetwork("1234::/128").iter_hosts()) == []
     assert list(IPNetwork("192.168.0.0/31").iter_hosts()) == [IPAddress('192.168.0.0'),IPAddress('192.168.0.1')]
     assert list(IPNetwork("192.168.0.0/32").iter_hosts()) == [IPAddress('192.168.0.0')]
 
@@ -512,10 +510,6 @@ def test_rfc3021_subnets():
     assert IPNetwork('192.0.2.0/32').network == IPAddress('192.0.2.0')
     assert IPNetwork('192.0.2.0/32').broadcast is None
     assert list(IPNetwork('192.0.2.0/32').iter_hosts()) == [IPAddress('192.0.2.0')]
-
-    # IPv6 must not be affected
-    assert IPNetwork('abcd::/127').broadcast is not None
-    assert IPNetwork('abcd::/128').broadcast is not None
 
 
 def test_ipnetwork_change_prefixlen():

--- a/netaddr/tests/ip/test_ip_v6.py
+++ b/netaddr/tests/ip/test_ip_v6.py
@@ -147,3 +147,22 @@ def test_ipv6_unicast_address_allocation_info():
     assert ip.info.IPv6_unicast[0].description == 'LACNIC'
     assert ip.info.IPv6_unicast[0].whois == 'whois.lacnic.net'
     assert ip.info.IPv6_unicast[0].status == 'ALLOCATED'
+
+def test_rfc6164_subnets():
+    # Tests for /127 subnet
+    assert list(IPNetwork('1234::/127')) == [
+        IPAddress('1234::'),
+        IPAddress('1234::1'),
+    ]
+    assert list(IPNetwork('1234::/127').iter_hosts()) == [
+        IPAddress('1234::'),
+        IPAddress('1234::1'),
+    ]
+    assert IPNetwork('1234::/127').network == IPAddress('1234::')
+    assert IPNetwork('1234::').broadcast is None
+
+    # Tests for /128 subnet
+    assert IPNetwork("1234::/128").network == IPAddress('1234::')
+    assert IPNetwork("1234::/128").broadcast is None
+    assert list(IPNetwork("1234::/128")) == [IPAddress('1234::')]
+    assert list(IPNetwork("1234::/128").iter_hosts()) == [IPAddress('1234::')]


### PR DESCRIPTION
This is a cherry pick of commit [1] later temporarily reverted in [2] to unblock the 0.8.0 release.

The original commit message:

    Like RFC 3021, IPv6 defines point-to-point subnets that must
    be handled separately, i.e. don't reserve first IP address.

    This patch aims to implement this, while refactoring code in
    iter_host function to reduce code duplication.

    Tests for this feature also added to ensure there is no regression.

    Signed-off-by: Damien Claisse <d.claisse@criteo.com>

We're preparing 0.9.0 release so this can land again (for good this time).

[1] 2984c0a40a70 ("Handle RFC 6164 IPv6 addresses")
[2] 67f1992e73df ("Revert "Handle RFC 6164 IPv6 addresses"")