### PR TITLE
Re-add myself as a maintainer in the package metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -118,6 +118,8 @@ def main():
     setup_options = dict(
         author='David P. D. Moss, Stefan Nordhausen et al',
         author_email='drkjam@gmail.com',
+        maintainer='Jakub Stasiak',
+        maintainer_email='jakub@stasiak.at',
         classifiers=classifiers,
         description='A network address manipulation library for Python',
         download_url='https://pypi.org/project/netaddr/',


### PR DESCRIPTION
We've had something like that before and it didn't play well with PyPI so I reverted it[1].

Let's see if it works any better now.

[1] 6401deeaa308 ("Un-revert "- PKG-INFO metadata generation seems to be broken (lists maintainer as author on PyPI - mutually exclusive?)""")