### PR TITLE
Delete `a` temp var in `netaddr.core`

### DIFF
--- a/netaddr/core.py
+++ b/netaddr/core.py
@@ -52,6 +52,7 @@ try:
     a = 42
     a.bit_length()
     # No exception, must be Python 2.7 or 3.1+ -> can use bit_length()
+    del a
     def num_bits(int_val):
         """
         :param int_val: an unsigned integer.


### PR DESCRIPTION
Right now this variable is still in a module's namespace as a global one:

```python
>>> from netaddr.core import a
>>> a
42
```

Two problems:
1. We should not have these names to leak to users, because this is an internal stuff
2. External tools like `typeshed` detect this variable https://github.com/python/typeshed/blob/8597724ac113d187d2ebc9f58cef3b410b1d5dae/stubs/netaddr/%40tests/stubtest_allowlist.txt#L3 and we have to ignore from our CI checks

So, there's no clear point to keep it, but there are clear points to remove it from the global namespace of this module.