### PR TITLE
Improve Python 3.13 compatibility

### DIFF
--- a/netaddr/compat.py
+++ b/netaddr/compat.py
@@ -91,3 +91,9 @@ try:
     from importlib import resources as _importlib_resources
 except ImportError:
     import importlib_resources as _importlib_resources
+
+try:
+    _open_binary = _importlib_resources.open_binary
+except AttributeError:
+    def _open_binary(pkg, res):
+        return _importlib_resources.files(pkg).joinpath(res).open('rb')

--- a/netaddr/eui/__init__.py
+++ b/netaddr/eui/__init__.py
@@ -13,7 +13,7 @@ from netaddr.strategy import eui48 as _eui48, eui64 as _eui64
 from netaddr.strategy.eui48 import mac_eui48
 from netaddr.strategy.eui64 import eui64_base
 from netaddr.ip import IPAddress
-from netaddr.compat import _importlib_resources, _is_int, _is_str
+from netaddr.compat import _open_binary, _is_int, _is_str
 
 
 class BaseIdentifier(object):
@@ -91,7 +91,7 @@ class OUI(BaseIdentifier):
 
         #   Discover offsets.
         if self._value in ieee.OUI_INDEX:
-            fh = _importlib_resources.open_binary(__package__, 'oui.txt')
+            fh = _open_binary(__package__, 'oui.txt')
             for (offset, size) in ieee.OUI_INDEX[self._value]:
                 fh.seek(offset)
                 data = fh.read(size).decode('UTF-8')
@@ -261,7 +261,7 @@ class IAB(BaseIdentifier):
 
         #   Discover offsets.
         if self._value in ieee.IAB_INDEX:
-            fh = _importlib_resources.open_binary(__package__, 'iab.txt')
+            fh = _open_binary(__package__, 'iab.txt')
             (offset, size) = ieee.IAB_INDEX[self._value][0]
             self.record['offset'] = offset
             self.record['size'] = size

--- a/netaddr/eui/ieee.py
+++ b/netaddr/eui/ieee.py
@@ -35,7 +35,7 @@ More details can be found at the following URLs :-
 import os.path as _path
 import csv as _csv
 
-from netaddr.compat import _bytes_type, _importlib_resources
+from netaddr.compat import _bytes_type, _open_binary
 from netaddr.core import Subscriber, Publisher
 
 
@@ -281,8 +281,8 @@ def load_index(index, fp):
 
 def load_indices():
     """Load OUI and IAB lookup indices into memory"""
-    load_index(OUI_INDEX, _importlib_resources.open_binary(__package__, 'oui.idx'))
-    load_index(IAB_INDEX, _importlib_resources.open_binary(__package__, 'iab.idx'))
+    load_index(OUI_INDEX, _open_binary(__package__, 'oui.idx'))
+    load_index(IAB_INDEX, _open_binary(__package__, 'iab.idx'))
 
 
 if __name__ == '__main__':

--- a/netaddr/ip/iana.py
+++ b/netaddr/ip/iana.py
@@ -34,7 +34,7 @@ from xml.sax import make_parser, handler
 
 from netaddr.core import Publisher, Subscriber
 from netaddr.ip import IPAddress, IPNetwork, IPRange, cidr_abbrev_to_verbose
-from netaddr.compat import _dict_items, _callable, _importlib_resources
+from netaddr.compat import _dict_items, _callable, _open_binary
 
 
 
@@ -367,21 +367,21 @@ def load_info():
     Parse and load internal IANA data lookups with the latest information from
     data files.
     """
-    ipv4 = IPv4Parser(_importlib_resources.open_binary(__package__, 'ipv4-address-space.xml'))
+    ipv4 = IPv4Parser(_open_binary(__package__, 'ipv4-address-space.xml'))
     ipv4.attach(DictUpdater(IANA_INFO['IPv4'], 'IPv4', 'prefix'))
     ipv4.parse()
 
-    ipv6 = IPv6Parser(_importlib_resources.open_binary(__package__, 'ipv6-address-space.xml'))
+    ipv6 = IPv6Parser(_open_binary(__package__, 'ipv6-address-space.xml'))
     ipv6.attach(DictUpdater(IANA_INFO['IPv6'], 'IPv6', 'prefix'))
     ipv6.parse()
 
     ipv6ua = IPv6UnicastParser(
-        _importlib_resources.open_binary(__package__, 'ipv6-unicast-address-assignments.xml'),
+        _open_binary(__package__, 'ipv6-unicast-address-assignments.xml'),
     )
     ipv6ua.attach(DictUpdater(IANA_INFO['IPv6_unicast'], 'IPv6_unicast', 'prefix'))
     ipv6ua.parse()
 
-    mcast = MulticastParser(_importlib_resources.open_binary(__package__, 'multicast-addresses.xml'))
+    mcast = MulticastParser(_open_binary(__package__, 'multicast-addresses.xml'))
     mcast.attach(DictUpdater(IANA_INFO['multicast'], 'multicast', 'address'))
     mcast.parse()
 

--- a/netaddr/tests/eui/test_ieee_parsers.py
+++ b/netaddr/tests/eui/test_ieee_parsers.py
@@ -3,7 +3,7 @@ import sys
 
 import pytest
 
-from netaddr.compat import _importlib_resources
+from netaddr.compat import _open_binary
 from netaddr.eui.ieee import OUIIndexParser, IABIndexParser, FileIndexer
 
 
@@ -11,7 +11,7 @@ from netaddr.eui.ieee import OUIIndexParser, IABIndexParser, FileIndexer
 def test_oui_parser_py2():
     from cStringIO import StringIO
     outfile = StringIO()
-    with contextlib.closing(_importlib_resources.open_binary(__package__, 'sample_oui.txt')) as infile:
+    with contextlib.closing(_open_binary(__package__, 'sample_oui.txt')) as infile:
         iab_parser = OUIIndexParser(infile)
         iab_parser.attach(FileIndexer(outfile))
         iab_parser.parse()
@@ -22,7 +22,7 @@ def test_oui_parser_py2():
 def test_iab_parser_py2():
     from cStringIO import StringIO
     outfile = StringIO()
-    with contextlib.closing(_importlib_resources.open_binary(__package__, 'sample_iab.txt')) as infile:
+    with contextlib.closing(_open_binary(__package__, 'sample_iab.txt')) as infile:
         iab_parser = IABIndexParser(infile)
         iab_parser.attach(FileIndexer(outfile))
         iab_parser.parse()
@@ -33,7 +33,7 @@ def test_iab_parser_py2():
 def test_oui_parser_py3():
     from io import StringIO
     outfile = StringIO()
-    with contextlib.closing(_importlib_resources.open_binary(__package__, 'sample_oui.txt')) as infile:
+    with contextlib.closing(_open_binary(__package__, 'sample_oui.txt')) as infile:
         iab_parser = OUIIndexParser(infile)
         iab_parser.attach(FileIndexer(outfile))
         iab_parser.parse()
@@ -44,7 +44,7 @@ def test_oui_parser_py3():
 def test_iab_parser_py3():
     from io import StringIO
     outfile = StringIO()
-    with contextlib.closing(_importlib_resources.open_binary(__package__, 'sample_iab.txt')) as infile:
+    with contextlib.closing(_open_binary(__package__, 'sample_iab.txt')) as infile:
         iab_parser = IABIndexParser(infile)
         iab_parser.attach(FileIndexer(outfile))
         iab_parser.parse()


### PR DESCRIPTION
importlib.resources.open_binary() has been deprecated

See:
https://docs.python.org/3.13/whatsnew/3.13.html
https://docs.python.org/3/library/importlib.resources.html#importlib.resources.open_binary

Originally reported via:
https://bugzilla.redhat.com/show_bug.cgi?id=2246093