### PR TITLE
Fix documentation warnings

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -120,7 +120,7 @@ html_theme = 'default'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.

--- a/netaddr/ip/__init__.py
+++ b/netaddr/ip/__init__.py
@@ -502,7 +502,7 @@ class IPAddress(BaseIP):
     def __bytes__(self):
         """ 
         :return: a bytes object equivalent to this IP address. In network
-        byte order, big-endian.
+            byte order, big-endian.
         """
         #   Python 3.x
         return self._value.to_bytes(self._module.width//8, 'big')

--- a/netaddr/ip/nmap.py
+++ b/netaddr/ip/nmap.py
@@ -108,7 +108,7 @@ def iter_nmap_range(*nmap_target_spec):
 
     See https://nmap.org/book/man-target-specification.html for details.
 
-    :param *nmap_target_spec: one or more nmap IP range target specification.
+    :param \*nmap_target_spec: one or more nmap IP range target specification.
 
     :return: an iterator producing IPAddress objects for each IP in the target spec(s).
     """


### PR DESCRIPTION
I want to enable some strictness flags in documentation builds so that warnings are treated as errors.

When working on that I discovered a few existing warnings:

    WARNING: html_static_path entry '_static' does not exist
    /Users/kuba/projects/netaddr/netaddr/ip/__init__.py:docstring of netaddr.ip.IPAddress.__bytes__:2: WARNING: Field list ends without a blank line; unexpected unindent.
    /Users/kuba/projects/netaddr/netaddr/ip/nmap.py:docstring of netaddr.ip.nmap.iter_nmap_range:6: WARNING: Inline emphasis start-string without end-string.

Let's resolve them.