### PR TITLE
Provide ReadTheDocs configuration

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -9,7 +9,7 @@ build:
     python: "3.12"
 
 sphinx:
-  configuration: docs/conf.py
+  configuration: docs/source/conf.py
   fail_on_warning: true
 
 # TODO: pin the development dependency versions

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -12,8 +12,10 @@ sphinx:
   configuration: docs/source/conf.py
   fail_on_warning: true
 
+python:
+  install:
+    - method: pip
+      path: .
 # TODO: pin the development dependency versions
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-# python:
-#   install:
 #     - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,19 @@
+# Read the Docs configuration file for Sphinx projects
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.12"
+
+sphinx:
+  configuration: docs/conf.py
+  fail_on_warning: true
+
+# TODO: pin the development dependency versions
+# See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
+# python:
+#   install:
+#     - requirements: docs/requirements.txt


### PR DESCRIPTION
RTD has been requiring a configuration file for a while, this change should resolve the documentation build failures[1].

[1] https://readthedocs.org/projects/netaddr/builds/22845819/