### PR TITLE
Change the documentation theme to Furo

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,8 +16,7 @@ python:
   install:
     - method: pip
       path: .
-    - method: pip
-      path: sphinx_rtd_theme
+    - requirements: docs/requirements.txt
 # TODO: pin the development dependency versions
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 #     - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,6 +16,8 @@ python:
   install:
     - method: pip
       path: .
+    - method: pip
+      path: sphinx_rtd_theme
 # TODO: pin the development dependency versions
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
 #     - requirements: docs/requirements.txt

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,8 @@ dist: clean doc
 
 doc:
 	@echo 'building documentation'
-	pip install sphinx sphinx-rtd-theme
+	pip install sphinx
+	pip install -r docs/requirements.txt
 	python setup.py develop
 	cd docs/ && $(MAKE) -f Makefile clean html
 	cd docs/build/html && zip -r ../netaddr.zip *

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ dist: clean doc
 
 doc:
 	@echo 'building documentation'
-	pip install sphinx
+	pip install sphinx sphinx-rtd-theme
 	python setup.py develop
 	cd docs/ && $(MAKE) -f Makefile clean html
 	cd docs/build/html && zip -r ../netaddr.zip *

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,1 @@
+sphinx_rtd_theme

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,1 @@
-sphinx_rtd_theme
+furo

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -91,7 +91,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'default'
+html_theme = 'sphinx_rtd_theme'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -91,7 +91,7 @@ pygments_style = 'sphinx'
 
 # The theme to use for HTML and HTML Help pages.  See the documentation for
 # a list of builtin themes.
-html_theme = 'sphinx_rtd_theme'
+html_theme = 'furo'
 
 # Theme options are theme-specific and customize the look and feel of a theme
 # further.  For a list of options available for each theme, see the


### PR DESCRIPTION
The default one feels a bit outdated to me, let's try this[1].

I initially wanted to go with the RTD theme but it doesn't
support dark mode natively[2].

The theme is used in Python Developer's Guide[3] and it looks
nice in my opinion.

[1] https://github.com/pradyunsg/furo#elevator-pitch
[2] https://github.com/readthedocs/sphinx_rtd_theme/issues/224
[3] https://devguide.python.org/