### PR TITLE
Make pytest run doctests

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,0 @@
-[tool.pytest.ini_options]
-addopts = "--doctest-modules --doctest-glob=\"*.rst\""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,2 @@
+[tool.pytest.ini_options]
+addopts = "--doctest-modules --doctest-glob=\"*.rst\""

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,2 +1,2 @@
 [pytest]
-addopts = --cov-report term --cov-report html --cov-report xml --cov-report term-missing --cov=netaddr --cov-branch
+addopts = --cov-report term --cov-report html --cov-report xml --cov-report term-missing --cov=netaddr --cov-branch --doctest-modules --doctest-glob="*.rst"


### PR DESCRIPTION
This includes doctests found in the docstrings in the code and doctests from the .rst files.

We currently don't have either in the code but I intend to add some and I'd like this piece of infrastructure in place first.