### PR TITLE
Ignore the .coverage test artifact

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ docs/build/
 .vagrant/
 tmp/
 *.iml
+.coverage
 coverage.xml
 htmlcov/
 junit.xml


### PR DESCRIPTION
Seems like it's been missing from our .gitignore.