### PR TITLE
Hide non-constructor dunder methods from the documentation

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -66,8 +66,13 @@ The following constants are used by the various *flags* arguments on netaddr cla
 Custom Exceptions
 -----------------
 .. autoexception:: netaddr.AddrConversionError
+    :exclude-members: __init__
+
 .. autoexception:: netaddr.AddrFormatError
+    :exclude-members: __init__
+
 .. autoexception:: netaddr.NotRegisteredError
+    :exclude-members: __init__
 
 ------------
 IP addresses
@@ -79,7 +84,6 @@ The `IPAddress` class is used to identify individual IP addresses.
 
 .. autoclass:: netaddr.IPAddress
     :members:
-    :special-members:
 
 ^^^^^^^^^^^^^^^^^^^^^^^^
 IPv6 formatting dialects
@@ -106,7 +110,6 @@ Nowadays, IP networks are usually specified using the CIDR format with a prefix 
 
 .. autoclass:: netaddr.IPNetwork
     :members:
-    :special-members:
 
 ---------------------------
 Arbitrary IP address ranges
@@ -124,7 +127,6 @@ A bounded range is a group of IP addresses specified using a start and end addre
 
 .. autoclass:: netaddr.IPRange
     :members:
-    :special-members:
 
 ^^^^^^^^^^^^^^
 IP glob ranges
@@ -136,7 +138,6 @@ The `IPGlob` class is used to represent individual glob ranges.
 
 .. autoclass:: netaddr.IPGlob
     :members:
-    :special-members:
 
 ^^^^^^^^^^^^^^^^^^
 globbing functions
@@ -171,7 +172,6 @@ The `IPSet` class was built specifically for this purpose.
 
 .. autoclass:: netaddr.IPSet
     :members:
-    :special-members:
 
 ---------------------------
 IP functions and generators
@@ -200,15 +200,12 @@ The `EUI` class is used to represents MACs (as well as their larger and less com
 
 .. autoclass:: netaddr.EUI
     :members:
-    :special-members:
 
 .. autoclass:: netaddr.OUI
     :members:
-    :special-members:
 
 .. autoclass:: netaddr.IAB
     :members:
-    :special-members:
 
 ^^^^^^^^^^^^^^^^^^^^^^^
 MAC formatting dialects

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -248,3 +248,9 @@ texinfo_documents = [
 # Warn about invalid references
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-nitpicky
 nitpicky = True
+
+#autodoc_class_signature = 'separated'
+
+autodoc_default_options = {
+    'special-members': '__init__',
+}


### PR DESCRIPTION
I don't imagine they're terribly useful and I believe they create more issues than they actually solve.

I expect no user is gonna care that __iadd__ is implemented and what it means, they're probably gonna be more interested in the fact that you can do

    ip = IPAddress('10.0.0.1')
    ip += 1

I think Python's ipaddress documentation does it right as it lists various conversion options and operator use[1], we should probably get something like that in place.

One exception is we still want to show the constructors so some configuration added + custom exclusion options for exceptions, otherwise the documentation would show the dummy __init__(*args, **kwargs) constructors for them which doesn't help anyone.

[1] https://docs.python.org/3/library/ipaddress.html#conversion-to-strings-and-integers