### PR TITLE
Link to formatting dialects instead of only mentioning them

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -83,6 +83,8 @@ The `IPAddress` class is used to identify individual IP addresses.
 .. autoclass:: netaddr.IPAddress
     :members:
 
+.. _ipv6_formatting_dialects:
+
 ^^^^^^^^^^^^^^^^^^^^^^^^
 IPv6 formatting dialects
 ^^^^^^^^^^^^^^^^^^^^^^^^
@@ -204,6 +206,8 @@ The `EUI` class is used to represents MACs (as well as their larger and less com
 
 .. autoclass:: netaddr.IAB
     :members:
+
+.. _mac_formatting_dialects:
 
 ^^^^^^^^^^^^^^^^^^^^^^^
 MAC formatting dialects

--- a/netaddr/eui/__init__.py
+++ b/netaddr/eui/__init__.py
@@ -356,8 +356,8 @@ class EUI(BaseIdentifier):
             48 or 64. Mainly used to distinguish EUI-48 and EUI-64 identifiers \
             specified as integers which may be numerically equivalent.
 
-        :param dialect: (optional) the mac_* dialect to be used to configure \
-            the formatting of EUI-48 (MAC) addresses.
+        :param dialect: (optional) one of the :ref:`mac_formatting_dialects` to
+            be used to configure the formatting of EUI-48 (MAC) addresses.
         """
         super(EUI, self).__init__()
 
@@ -734,8 +734,8 @@ class EUI(BaseIdentifier):
         Format the EUI into the representational format according to the given
         dialect
 
-        :param dialect: the mac_* dialect defining the formatting of EUI-48 \
-            (MAC) addresses.
+        :param dialect: one of the :ref:`mac_formatting_dialects` defining the
+            formatting of EUI-48 (MAC) addresses.
 
         :return: EUI in representational format according to the given dialect
         """

--- a/netaddr/ip/__init__.py
+++ b/netaddr/ip/__init__.py
@@ -597,7 +597,7 @@ class IPAddress(BaseIP):
         """
         Only relevant for IPv6 addresses. Has no effect for IPv4.
 
-        :param dialect: An ipv6_* dialect class.
+        :param dialect: One of the :ref:`ipv6_formatting_dialects`.
 
         :return: an alternate string representation for this IP address.
         """


### PR DESCRIPTION
Seems like a good thing to have in the documentation and it's simple enough to add.