### PR TITLE
Show BaseIP-inherited properties in IPAddress' documentation

### DIFF
--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -82,6 +82,7 @@ The `IPAddress` class is used to identify individual IP addresses.
 
 .. autoclass:: netaddr.IPAddress
     :members:
+    :inherited-members:
 
 ^^^^^^^^^^^^^^^^^^^^^^^^
 IPv6 formatting dialects


### PR DESCRIPTION
These all (is_ipv4_mapped(), is_link_local() etc.) are a valuable and important part of IPAddress' public interface.