### PR TITLE
Implement IPAddress.to_canonical()

### DIFF
--- a/netaddr/ip/__init__.py
+++ b/netaddr/ip/__init__.py
@@ -668,6 +668,25 @@ class IPAddress(BaseIP):
         """:return: Python statement to create an equivalent object"""
         return "%s('%s')" % (self.__class__.__name__, self)
 
+    def to_canonical(self):
+        """
+        Converts the address to IPv4 if it is an IPv4-mapped IPv6 address (`RFC 4291
+        Section 2.5.5.2 <https://datatracker.ietf.org/doc/html/rfc4291.html#section-2.5.5.2>`_),
+        otherwise returns the address as-is.
+
+        >>> # IPv4-mapped IPv6
+        >>> IPAddress('::ffff:10.0.0.1').to_canonical()
+        IPAddress('10.0.0.1')
+        >>>
+        >>> # Everything else
+        >>> IPAddress('::1').to_canonical()
+        IPAddress('::1')
+        >>> IPAddress('10.0.0.1').to_canonical()
+        IPAddress('10.0.0.1')
+        """
+        if not self.is_ipv4_mapped():
+            return self
+        return self.ipv4()
 
 class IPListMixin(object):
     """


### PR DESCRIPTION
This is one of the pieces missing to have a good IPv4-mapped IPv6 address handling story.

Following Rust's IpAddr::to_canonical() design[1][2][3] which seems sensible to me (except that ours is simpler as we don't have separate types for IPv4 and IPv6 addresses – yet).

Also, relying on doctests[4] to test this feature – no need to make things more difficult than they need to be.

[1] https://doc.rust-lang.org/std/net/enum.IpAddr.html#method.to_canonical
[2] https://doc.rust-lang.org/std/net/struct.Ipv6Addr.html#method.to_canonical
[3] https://github.com/rust-lang/rust/pull/87708
[4] 3290b50baa64 ("Make pytest run doctests (#280)")