### PR TITLE
Reorganize the documentation

### DIFF
--- a/docs/source/how-to.rst
+++ b/docs/source/how-to.rst
@@ -1,0 +1,10 @@
+How-to guides
+=============
+
+The pages in this section contain practical steps that serve our work.
+They are task-oriented.
+
+.. toctree::
+    :maxdepth: 1
+
+    installation

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -2,21 +2,45 @@
 netaddr 0.9.0 documentation
 ===========================
 
+netaddr's documentation uses the `Diátaxis approach to technical documentation
+authoring <https://diataxis.fr/>`_ and consists of the following modes of
+documentation:
+
+.. list-table::
+   :header-rows: 1
+   :width: 100%
+
+   * - Mode
+     - Contains
+     - Serves
+     - Oriented on
+   * - :doc:`tutorials`
+     - Practical steps
+     - Our study
+     - Learning
+   * - :doc:`how-to`
+     - Practical steps
+     - Our work
+     - Tasks
+   * - :doc:`reference`
+     - Theoretical knowledge
+     - Our work
+     - Information
+   * - Explanation (does not exist right now)
+     - Theoretical knowledge
+     - Our study
+     - Understanding
+
 .. toctree::
     :maxdepth: 1
+    :hidden:
 
     introduction
-    installation
-    tutorial_01
-    tutorial_02
-    tutorial_03
-    api
-    changes
-    references
+    tutorials
+    how-to
+    reference
     authors
     contributors
-    copyright
-    license
 
 ------------------
 Indices and tables

--- a/docs/source/installation.rst
+++ b/docs/source/installation.rst
@@ -1,5 +1,5 @@
-==================
-Installing netaddr
-==================
+======================
+How to install netaddr
+======================
 
 .. include:: ../../INSTALL

--- a/docs/source/reference.rst
+++ b/docs/source/reference.rst
@@ -1,0 +1,15 @@
+Reference
+=========
+
+The pages in this section contain theoretical knowledge that serves our work.
+They are information-oriented.
+
+.. toctree::
+    :maxdepth: 1
+
+    installation
+    api
+    changes
+    references
+    copyright
+    license

--- a/docs/source/tutorials.rst
+++ b/docs/source/tutorials.rst
@@ -1,0 +1,12 @@
+Tutorials
+=========
+
+The pages in this section contain practical steps that serve our study.
+They are learning-oriented.
+
+.. toctree::
+    :maxdepth: 1
+
+    tutorial_01
+    tutorial_02
+    tutorial_03


### PR DESCRIPTION
I've been big fan of the Diataxis documentation framework, both as a documentation reader and a writer.

Some of the content we have doesn't necessarily fit one of the modes *perfectly* but that's fine, it's a start.

Notable I left the Introduction section outside of the modes (I intend to remove it altogether) and the Authors and Contributors sections I'm not sure what to do about.

I also changed one document's title so that it fits the format expected by the How-to guides (How to ...).

[1] https://diataxis.fr/