### PR TITLE
Style external links in the documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -120,7 +120,7 @@ html_theme = 'furo'
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-# html_static_path = ['_static']
+html_static_path = ['static']
 
 # If not '', a 'Last updated on:' timestamp is inserted at every page bottom,
 # using the given strftime format.
@@ -254,3 +254,6 @@ nitpicky = True
 autodoc_default_options = {
     'special-members': '__init__',
 }
+
+
+html_css_files = ['custom.css']

--- a/docs/source/static/custom.css
+++ b/docs/source/static/custom.css
@@ -1,0 +1,5 @@
+article a.reference.external::after {
+      content: url('data:image/svg+xml,<svg width="12" height="12" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" stroke-width="1.5" stroke="%23607D8B" fill="none" stroke-linecap="round" stroke-linejoin="round"><path stroke="none" d="M0 0h24v24H0z"/><path d="M11 7h-5a2 2 0 0 0 -2 2v9a2 2 0 0 0 2 2h9a2 2 0 0 0 2 -2v-5" /><line x1="10" y1="14" x2="20" y2="4" /><polyline points="15 4 20 4 20 9" /></svg>');
+      margin: 0 0.1em;
+      vertical-align: middle;
+}


### PR DESCRIPTION
I sometimes find it useful to see if a link takes me to "the outside" or if I'm still gonna be in the documentation when I click it.

The style snippet taken almost verbatim from [1].

[1] https://github.com/pradyunsg/furo/discussions/348#discussioncomment-1931019