### PR TITLE
Make the release process instructions part of the documentation

### DIFF
--- a/docs/source/dev-how-to/index.rst
+++ b/docs/source/dev-how-to/index.rst
@@ -1,0 +1,7 @@
+How-to guides
+=============
+
+.. toctree::
+    :maxdepth: 1
+
+    release

--- a/docs/source/dev-how-to/release.rst
+++ b/docs/source/dev-how-to/release.rst
@@ -1,6 +1,6 @@
------------------------
-netaddr release process
------------------------
+----------------------
+How to release netaddr
+----------------------
 
 Here is how to go about releasing a new version of `netaddr`.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -37,12 +37,20 @@ documentation:
 .. toctree::
     :maxdepth: 1
     :hidden:
+    :caption: User documentation
 
     tutorials
     how-to
     reference
     authors
     contributors
+
+.. toctree::
+    :maxdepth: 1
+    :hidden:
+    :caption: Developer documentation
+
+    dev-how-to/index
 
 ------------------
 Indices and tables


### PR DESCRIPTION
Less noise in the working directory, more structure to the documentation.

Changed the title to fit the "How to ..." format.