### PR TITLE
Protect against constructing objects with invalid flags

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,10 @@ Deprecated:
 
 * Deprecate Python 3.7 support
 
+Other:
+
+* Raise an exception if invalid flags are passed to ``IPAddress``, ``IPNetwork`` or ``IPRange``
+
 --------------
 Release: 0.9.0
 --------------

--- a/netaddr/ip/__init__.py
+++ b/netaddr/ip/__init__.py
@@ -287,6 +287,9 @@ class IPAddress(BaseIP):
         """
         super(IPAddress, self).__init__()
 
+        if flags & ~(INET_PTON | ZEROFILL):
+            raise ValueError('Unrecognized IPAddress flags value: %s' % (flags,))
+
         if isinstance(addr, BaseIP):
             #   Copy constructor.
             if version is not None and version != addr._module.version:
@@ -968,6 +971,9 @@ class IPNetwork(BaseIP, IPListMixin):
             IPNetwork('1.2.3.0/24')
         """
         super(IPNetwork, self).__init__()
+
+        if flags & ~NOHOST:
+            raise ValueError('Unrecognized IPAddress flags value: %s' % (flags,))
 
         value, prefixlen, module = None, None, None
 

--- a/netaddr/tests/ip/test_ip.py
+++ b/netaddr/tests/ip/test_ip.py
@@ -1,8 +1,18 @@
 import weakref
 
-from netaddr import IPAddress, IPNetwork, IPRange
+import pytest
+
+from netaddr import INET_PTON, IPAddress, IPNetwork, IPRange, NOHOST
 
 def test_ip_classes_are_weak_referencable():
     weakref.ref(IPAddress('10.0.0.1'))
     weakref.ref(IPNetwork('10.0.0.1/8'))
     weakref.ref(IPRange('10.0.0.1', '10.0.0.10'))
+
+def test_invalid_ipaddress_flags_are_rejected():
+    with pytest.raises(ValueError):
+        IPAddress('1.2.3.4', flags=NOHOST)
+
+def test_invalid_ipnetwork_flags_are_rejected():
+    with pytest.raises(ValueError):
+        IPNetwork('1.2.0.0/16', flags=INET_PTON)


### PR DESCRIPTION
Ignoring invalid flags is likely to lead to hard to debug issues, better reject them right away.