### PR TITLE
Deprecate the support for abbreviated CIDR format

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -7,6 +7,8 @@ Date: YYYY-MM-DD
 Deprecated:
 
 * Deprecate Python 3.7 support
+* Deprecate abbreviated CIDR format support in :class:`~netaddr.IPNetwork`
+  (``implicit_prefix=True``)
 
 --------------
 Release: 0.9.0

--- a/netaddr/ip/__init__.py
+++ b/netaddr/ip/__init__.py
@@ -929,6 +929,8 @@ class IPNetwork(BaseIP, IPListMixin):
         x.x.0.0/y   -> 192.168.0.0/16
         x.x.x.0/y   -> 192.168.0.0/24
 
+       .. deprecated:: NEXT_NETADDR_VERSION
+
     .. warning::
 
         The next release (0.9.0) will contain a backwards incompatible change
@@ -953,6 +955,8 @@ class IPNetwork(BaseIP, IPListMixin):
             classful IPv4 rules to select a default prefix when one is not
             provided. If False it uses the length of the IP address version.
             (default: False)
+
+            .. deprecated:: NEXT_NETADDR_VERSION
 
         :param version: (optional) optimizes version detection if specified
             and distinguishes between IPv4 and IPv6 for addresses with an


### PR DESCRIPTION
Following a TODO from parse_ip_network():

    if implicit_prefix:
        #TODO: deprecate this option in netaddr 0.8.x
        addr = cidr_abbrev_to_verbose(addr)

Seems good to get rid of this, can potentially lead to ambiguous outcomes.