### PR TITLE
Refactor IP category tests

### DIFF
--- a/netaddr/tests/ip/test_ip_categories.py
+++ b/netaddr/tests/ip/test_ip_categories.py
@@ -1,52 +1,74 @@
+import pytest
+
 from netaddr import IPAddress
 
+# Excluding is_ipv4_compat as we'll likely be dropping it
+unicast = 1 << 0
+multicast = 1 << 1
+loopback = 1 << 2
+private = 1 << 3
+link_local = 1 << 4
+reserved = 1 << 5
+ipv4_mapped = 1 << 6
+hostmask = 1 << 7
+netmask = 1 << 8
 
-def test_is_unicast():
-    assert IPAddress('192.0.2.1').is_unicast()
-    assert IPAddress('fe80::1').is_unicast()
-
-
-def test_is_multicast():
-    assert IPAddress('239.192.0.1').is_multicast()
-    assert IPAddress('ff00::1').is_multicast()
-
-
-def test_is_private():
-    assert IPAddress('172.24.0.1').is_private()
-    assert IPAddress('10.0.0.1').is_private()
-    assert IPAddress('192.168.0.1').is_private()
-    assert IPAddress('fc00::1').is_private()
-    assert IPAddress('198.18.0.0').is_private()
-    assert IPAddress('198.19.255.255').is_private()
-
-
-def test_is_reserved():
-    assert IPAddress('253.0.0.1').is_reserved()
-    assert IPAddress('192.0.2.0').is_reserved()
-    assert IPAddress('192.0.2.255').is_reserved()
-    assert IPAddress('127.0.0.0').is_reserved()
-    assert IPAddress('127.255.255.255').is_reserved()
-    assert IPAddress('192.88.99.0').is_reserved()
-    assert IPAddress('192.88.99.255').is_reserved()
-    assert IPAddress('0.0.0.0').is_reserved()
-    assert IPAddress('0.255.255.255').is_reserved()
-    assert IPAddress('233.252.0.0').is_reserved()
-    assert IPAddress('233.252.0.255').is_reserved()
+flags = {
+    'unicast': unicast,
+    'multicast': multicast,
+    'loopback': loopback,
+    'private': private,
+    'link_local': link_local,
+    'reserved': reserved,
+    'ipv4_mapped': ipv4_mapped,
+    'hostmask': hostmask,
+    'netmask': netmask,
+}
 
 
-def test_is_public():
-    ip = IPAddress('62.125.24.5')
-    assert ip.is_unicast() and not ip.is_private()
+@pytest.mark.parametrize('text_address,categories', [
+    # IPv4
+    ['0.0.0.0', reserved | hostmask | netmask | unicast],
+    ['0.0.1.255', hostmask | reserved | unicast | hostmask],
+    ['0.255.255.255', reserved | hostmask | unicast],
+    ['10.0.0.1', private | unicast],
+    ['62.125.24.5', unicast],
+    ['127.0.0.0', reserved | loopback | unicast | reserved],
+    ['127.0.0.1', loopback | reserved | unicast],
+    ['172.24.0.1', private | unicast],
+    ['127.255.255.255', reserved | hostmask | loopback | unicast],
+    ['192.0.2.0', reserved | unicast],
+    ['192.0.2.1', reserved | unicast],
+    ['192.0.2.255', reserved | unicast],
+    ['192.88.99.0', reserved | unicast],
+    ['192.88.99.255', reserved | unicast],
+    ['192.168.0.1', private | unicast],
+    ['198.18.0.0', private | unicast],
+    ['198.19.255.255', private | unicast],
+    ['233.252.0.0', reserved | multicast],
+    ['233.252.0.255', reserved | multicast],
+    ['239.192.0.1', private | multicast],
+    ['253.0.0.1', reserved | unicast],
+    ['255.255.254.0', netmask | reserved | unicast],
+    # IPv6
+    ['::1', loopback | hostmask | reserved | unicast],
+    ['fc00::1', private | unicast],
+    ['fe80::1', private | unicast | link_local],
+    ['ff00::1', reserved | multicast],
+])
+def test_ip_categories(text_address, categories):
+    address = IPAddress(text_address)
+    methods = [
+        getattr(address, name)
+        for name in dir(address) if name.startswith('is_') and name != 'is_ipv4_compat'
+    ]
+    for method in methods:
+        name = method.__name__.replace('is_', '')
+        flag = flags[name]
+        got_value = method()
+        expected_value = bool(categories & flag)
+        assert got_value == expected_value, 'Expected is_%s() value to be %s' % (name, expected_value)
+        categories &= ~flag
 
-
-def test_is_netmask():
-    assert IPAddress('255.255.254.0').is_netmask()
-
-
-def test_is_hostmask():
-    assert IPAddress('0.0.1.255').is_hostmask()
-
-
-def test_is_loopback():
-    assert IPAddress('127.0.0.1').is_loopback()
-    assert IPAddress('::1').is_loopback()
+    # Just one final check to make sure we haven't missed any flags
+    assert categories == 0


### PR DESCRIPTION
There was quite a bit of repetition there and for the addresses we have in the test code we were only verifying some of their is_*() values.

Considering I want to add some new is_*() methods I figured I'd refactor the code first so that the test suite is more robust and it's easier to discover invalid assumptions or other mistakes.

I got the refactoring idea after reading the Rust core library tests for a similar feature[1].

The addresses we test are the same as before, just reordered.

There are some... interesting category assignments that this change surfaced, we could probably revisit some of them.

[1] https://github.com/rust-lang/rust/blob/767453eb7ca188e991ac5568c17b984dd4893e77/library/core/tests/net/ip_addr.rs#L475C12-L475C12