### PR TITLE
Add a way to request legacy IPv4 parsing from IPAddress

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,11 @@ NEXT_NETADDR_VERSION
 
 Date: YYYY-MM-DD
 
+Added:
+
+* Add a :data:`~netaddr.INET_ATON` flag to explicitly request ``inet_aton()`` IPv4 parsing semantics
+  from :class:`~netaddr.IPAddress`
+
 Deprecated:
 
 * Deprecate Python 3.7 support

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -49,6 +49,14 @@ The following constants are used by the various *flags* arguments on netaddr cla
 
    See the :meth:`IPAddress.__init__` documentation for details.
 
+.. data:: netaddr.INET_ATON
+
+    Use ``inet_aton()`` semantics when parsing IPv4.
+
+    See the :meth:`IPAddress.__init__` documentation for details.
+
+    .. versionadded:: NEXT_NETADDR_VERSION
+
 .. data:: netaddr.Z
           netaddr.ZEROFILL
 

--- a/netaddr/__init__.py
+++ b/netaddr/__init__.py
@@ -16,7 +16,7 @@ if _sys.version_info[0:2] < (2, 4):
     raise RuntimeError('Python 2.4.x or higher is required!')
 
 from netaddr.core import (AddrConversionError, AddrFormatError,
-    NotRegisteredError, ZEROFILL, Z, INET_PTON, P, NOHOST, N)
+    NotRegisteredError, ZEROFILL, Z, INET_ATON, INET_PTON, P, NOHOST, N)
 
 from netaddr.ip import (IPAddress, IPNetwork, IPRange, all_matching_cidrs,
     cidr_abbrev_to_verbose, cidr_exclude, cidr_merge, iprange_to_cidrs,

--- a/netaddr/core.py
+++ b/netaddr/core.py
@@ -22,6 +22,9 @@ Z = ZEROFILL = 2
 #:  Remove any host bits found to the right of an applied CIDR prefix.
 N = NOHOST = 4
 
+#: Use legacy ``inet_aton()`` semantics when parsing IPv4.
+INET_ATON = 8
+
 #-----------------------------------------------------------------------------
 #   Custom exceptions.
 #-----------------------------------------------------------------------------

--- a/netaddr/ip/__init__.py
+++ b/netaddr/ip/__init__.py
@@ -267,9 +267,9 @@ class IPAddress(BaseIP):
               >>> IPAddress('010.020.030.040')
               IPAddress('8.16.24.32')
 
-            * :data:`ZEROFILL` – like the default, except leading zeros are discarded:
+            * ``INET_ATON | ZEROFILL`` or :data:`ZEROFILL` – like the default, except leading zeros are discarded:
 
-              >>> IPAddress('010', flags=ZEROFILL)
+              >>> IPAddress('010', flags=INET_ATON | ZEROFILL)
               IPAddress('0.0.0.10')
 
             * :data:`INET_PTON` – requires four decimal octets:

--- a/netaddr/ip/__init__.py
+++ b/netaddr/ip/__init__.py
@@ -8,7 +8,7 @@
 import sys as _sys
 
 from netaddr.core import AddrFormatError, AddrConversionError, num_bits, \
-    DictDotLookup, NOHOST, N, INET_PTON, P, ZEROFILL, Z
+    DictDotLookup, NOHOST, N, INET_ATON, INET_PTON, P, ZEROFILL, Z
 
 from netaddr.strategy import ipv4 as _ipv4, ipv6 as _ipv6
 
@@ -256,7 +256,7 @@ class IPAddress(BaseIP):
 
             Allowed flag values:
 
-            * The default. Follows `inet_aton semantics
+            * The default (``0``) or :data:`INET_ATON`. Follows `inet_aton semantics
               <https://www.netmeister.org/blog/inet_aton.html>`_ and allows all kinds of
               weird-looking addresses to be parsed. For example:
 
@@ -287,8 +287,11 @@ class IPAddress(BaseIP):
         """
         super(IPAddress, self).__init__()
 
-        if flags & ~(INET_PTON | ZEROFILL):
+        if flags & ~(INET_PTON | ZEROFILL | INET_ATON):
             raise ValueError('Unrecognized IPAddress flags value: %s' % (flags,))
+
+        if flags & INET_ATON and flags & INET_PTON:
+            raise ValueError('INET_ATON and INET_PTON are mutually exclusive')
 
         if isinstance(addr, BaseIP):
             #   Copy constructor.
@@ -1984,11 +1987,14 @@ def all_matching_cidrs(ip, cidrs):
 IPV4_LOOPBACK  = IPNetwork('127.0.0.0/8')    #   Loopback addresses (RFC 990)
 
 IPV4_PRIVATE = (
-    IPNetwork('10.0.0.0/8'),        #   Class A private network local communication (RFC 1918)
+    IPNetwork('10.0.0.0/8'),        #XXX   Class A private network local communication (RFC 1918)
     IPNetwork('100.64.0.0/10'),     #   Carrier grade NAT (RFC 6598)
-    IPNetwork('172.16.0.0/12'),     #   Private network - local communication (RFC 1918)
+    IPNetwork('172.16.0.0/12'),     #XXX   Private network - local communication (RFC 1918)
     IPNetwork('192.0.0.0/24'),      #   IANA IPv4 Special Purpose Address Registry (RFC 5736)
-    IPNetwork('192.168.0.0/16'),    #   Class B private network local communication (RFC 1918)
+    # protocol assignments
+    IPNetwork('192.168.0.0/16'),    #XXX  Class B private network local communication (RFC 1918)
+    
+    # benchmarking
     IPNetwork('198.18.0.0/15'),     #  Testing of inter-network communications between subnets (RFC 2544)
     IPRange('239.0.0.0', '239.255.255.255'),    #   Administrative Multicast
 )

--- a/netaddr/ip/__init__.py
+++ b/netaddr/ip/__init__.py
@@ -1987,12 +1987,12 @@ def all_matching_cidrs(ip, cidrs):
 IPV4_LOOPBACK  = IPNetwork('127.0.0.0/8')    #   Loopback addresses (RFC 990)
 
 IPV4_PRIVATE = (
-    IPNetwork('10.0.0.0/8'),        #XXX   Class A private network local communication (RFC 1918)
+    IPNetwork('10.0.0.0/8'),        #   Class A private network local communication (RFC 1918)
     IPNetwork('100.64.0.0/10'),     #   Carrier grade NAT (RFC 6598)
-    IPNetwork('172.16.0.0/12'),     #XXX   Private network - local communication (RFC 1918)
+    IPNetwork('172.16.0.0/12'),     #   Private network - local communication (RFC 1918)
     IPNetwork('192.0.0.0/24'),      #   IANA IPv4 Special Purpose Address Registry (RFC 5736)
     # protocol assignments
-    IPNetwork('192.168.0.0/16'),    #XXX  Class B private network local communication (RFC 1918)
+    IPNetwork('192.168.0.0/16'),    #  Class B private network local communication (RFC 1918)
     
     # benchmarking
     IPNetwork('198.18.0.0/15'),     #  Testing of inter-network communications between subnets (RFC 2544)

--- a/netaddr/tests/ip/test_ip.py
+++ b/netaddr/tests/ip/test_ip.py
@@ -2,16 +2,17 @@ import weakref
 
 import pytest
 
-from netaddr import INET_PTON, IPAddress, IPNetwork, IPRange, NOHOST
+from netaddr import INET_ATON, INET_PTON, IPAddress, IPNetwork, IPRange, NOHOST
 
 def test_ip_classes_are_weak_referencable():
     weakref.ref(IPAddress('10.0.0.1'))
     weakref.ref(IPNetwork('10.0.0.1/8'))
     weakref.ref(IPRange('10.0.0.1', '10.0.0.10'))
 
-def test_invalid_ipaddress_flags_are_rejected():
+@pytest.mark.parametrize('flags', [NOHOST, INET_ATON | INET_PTON])
+def test_invalid_ipaddress_flags_are_rejected(flags):
     with pytest.raises(ValueError):
-        IPAddress('1.2.3.4', flags=NOHOST)
+        IPAddress('1.2.3.4', flags=flags)
 
 def test_invalid_ipnetwork_flags_are_rejected():
     with pytest.raises(ValueError):

--- a/netaddr/tests/ip/test_ip_v4.py
+++ b/netaddr/tests/ip/test_ip_v4.py
@@ -5,7 +5,7 @@ import sys
 
 import pytest
 
-from netaddr import IPAddress, IPNetwork, INET_PTON, spanning_cidr, AddrFormatError, ZEROFILL, Z, P, NOHOST
+from netaddr import IPAddress, IPNetwork, INET_ATON, INET_PTON, spanning_cidr, AddrFormatError, ZEROFILL, Z, P, NOHOST
 
 
 def test_ipaddress_v4():
@@ -345,6 +345,9 @@ def test_ipaddress_inet_aton_constructor_v4():
     assert IPAddress('127.1') == IPAddress('127.0.0.1')
     assert IPAddress('127.0.1') == IPAddress('127.0.0.1')
 
+    # Verify explicit INET_ATON is the same as the current default
+    assert IPAddress('127', flags=INET_ATON) == IPAddress('127')
+
 
 def test_ipaddress_inet_pton_constructor_v4():
     with pytest.raises(AddrFormatError):
@@ -369,6 +372,8 @@ def test_ipaddress_constructor_zero_filled_octets_v4():
     assert IPAddress('010.000.000.001') == IPAddress('8.0.0.1')
     assert IPAddress('010.000.000.001', flags=ZEROFILL) == IPAddress('10.0.0.1')
     assert IPAddress('010.000.001', flags=ZEROFILL) == IPAddress('10.0.0.1')
+    # Verify explicit INET_ATON is the same as the current default
+    assert IPAddress('010.000.000.001', flags=INET_ATON | ZEROFILL) == IPAddress('10.0.0.1')
 
     with pytest.raises(AddrFormatError):
         assert IPAddress('010.000.001', flags=INET_PTON|ZEROFILL)


### PR DESCRIPTION
I want to make the default parsing more restrictive (separate PRs)
and this is needed as an escape hatch for people who need the old
behavior.

No actual behavior changes yet, just preparations.