### PR TITLE
Introduce the INET_PTON_STRICT IPv4 parsing mode

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,6 +8,8 @@ Added:
 
 * Add a :data:`~netaddr.INET_ATON` flag to explicitly request ``inet_aton()`` IPv4 parsing semantics
   from :class:`~netaddr.IPAddress`
+* Add a :data:`~netaddr.INET_PTON_STRICT` IPv4 parsing mode – it's a strict, predictable mode that
+  will become the default in the future.
 
 Deprecated:
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -8,7 +8,7 @@ Added:
 
 * Add a :data:`~netaddr.INET_ATON` flag to explicitly request ``inet_aton()`` IPv4 parsing semantics
   from :class:`~netaddr.IPAddress`
-* Add a :data:`~netaddr.INET_PTON_STRICT` IPv4 parsing mode – it's a strict, predictable mode that
+* Add an :data:`~netaddr.INET_PTON_STRICT` IPv4 parsing mode – it's a strict, predictable mode that
   will become the default in the future.
 
 Deprecated:

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -42,6 +42,14 @@ Constants
 
 The following constants are used by the various *flags* arguments on netaddr class constructors.
 
+
+.. data:: netaddr.INET_PTON_STRICT
+
+    Use strict ``inet_pton()`` semantics when parsing IPv4: four decimal octets are required,
+    leading zeros disallowed.
+
+    .. versionadded:: NEXT_NETADDR_VERSION
+
 .. data:: netaddr.P
           netaddr.INET_PTON
 

--- a/netaddr/__init__.py
+++ b/netaddr/__init__.py
@@ -16,7 +16,7 @@ if _sys.version_info[0:2] < (2, 4):
     raise RuntimeError('Python 2.4.x or higher is required!')
 
 from netaddr.core import (AddrConversionError, AddrFormatError,
-    NotRegisteredError, ZEROFILL, Z, INET_ATON, INET_PTON, P, NOHOST, N)
+    NotRegisteredError, ZEROFILL, Z, INET_ATON, INET_PTON, INET_PTON_STRICT, P, NOHOST, N)
 
 from netaddr.ip import (IPAddress, IPNetwork, IPRange, all_matching_cidrs,
     cidr_abbrev_to_verbose, cidr_exclude, cidr_merge, iprange_to_cidrs,

--- a/netaddr/core.py
+++ b/netaddr/core.py
@@ -25,6 +25,10 @@ N = NOHOST = 4
 #: Use legacy ``inet_aton()`` semantics when parsing IPv4.
 INET_ATON = 8
 
+#: Use strict ``inet_pton()`` semantics when parsing IPv4 – leading zeros disallowed.
+INET_PTON_STRICT = 16
+
+
 #-----------------------------------------------------------------------------
 #   Custom exceptions.
 #-----------------------------------------------------------------------------

--- a/netaddr/ip/__init__.py
+++ b/netaddr/ip/__init__.py
@@ -8,7 +8,7 @@
 import sys as _sys
 
 from netaddr.core import AddrFormatError, AddrConversionError, num_bits, \
-    DictDotLookup, NOHOST, N, INET_ATON, INET_PTON, P, ZEROFILL, Z
+    DictDotLookup, NOHOST, N, INET_ATON, INET_PTON, INET_PTON_STRICT, P, ZEROFILL, Z
 
 from netaddr.strategy import ipv4 as _ipv4, ipv6 as _ipv6
 
@@ -284,14 +284,22 @@ class IPAddress(BaseIP):
 
               >>> IPAddress('010.020.030.040', flags=INET_PTON | ZEROFILL)
               IPAddress('10.20.30.40')
+
+            * :data:`netaddr.INET_PTON_STRICT` – the most predictable IPv4 parsing mode:
+              four decimal octets required, leading zeros disallowed.
+
+              Use this flag unless you specifically need more permissive behavior.
         """
         super(IPAddress, self).__init__()
 
-        if flags & ~(INET_PTON | ZEROFILL | INET_ATON):
+        if flags & ~(INET_PTON | ZEROFILL | INET_ATON | INET_PTON_STRICT):
             raise ValueError('Unrecognized IPAddress flags value: %s' % (flags,))
 
         if flags & INET_ATON and flags & INET_PTON:
             raise ValueError('INET_ATON and INET_PTON are mutually exclusive')
+
+        if flags & INET_PTON_STRICT and flags &~INET_PTON_STRICT:
+            raise ValueError('INET_PTON_STRICT cannot be combined with any other flags')
 
         if isinstance(addr, BaseIP):
             #   Copy constructor.

--- a/netaddr/strategy/ipv4.py
+++ b/netaddr/strategy/ipv4.py
@@ -18,7 +18,7 @@ else:
     #   All other cases, use all functions from the socket module.
     from socket import inet_pton as _inet_pton, AF_INET
 
-from netaddr.core import AddrFormatError, ZEROFILL, INET_PTON
+from netaddr.core import AddrFormatError, ZEROFILL, INET_PTON, INET_PTON_STRICT
 
 from netaddr.strategy import (
     valid_words as _valid_words, valid_bits as _valid_bits,
@@ -121,7 +121,13 @@ def str_to_int(addr, flags=0):
         addr = '.'.join(['%d' % int(i) for i in addr.split('.')])
 
     try:
-        if flags & INET_PTON:
+        if flags & INET_PTON_STRICT and any(
+            part != '0' and part.startswith('0') for part in addr.split('.')
+        ):
+            # Doesn't matter what we raise, it's just to trigger the raise in the except block
+            # below.
+            raise Exception()
+        if flags & (INET_PTON | INET_PTON_STRICT):
             return _struct.unpack('>I', _inet_pton(AF_INET, addr))[0]
         else:
             return _struct.unpack('>I', _inet_aton(addr))[0]

--- a/netaddr/tests/ip/test_ip.py
+++ b/netaddr/tests/ip/test_ip.py
@@ -2,14 +2,20 @@ import weakref
 
 import pytest
 
-from netaddr import INET_ATON, INET_PTON, IPAddress, IPNetwork, IPRange, NOHOST
+from netaddr import INET_ATON, INET_PTON, INET_PTON_STRICT, IPAddress, IPNetwork, IPRange, NOHOST, ZEROFILL
 
 def test_ip_classes_are_weak_referencable():
     weakref.ref(IPAddress('10.0.0.1'))
     weakref.ref(IPNetwork('10.0.0.1/8'))
     weakref.ref(IPRange('10.0.0.1', '10.0.0.10'))
 
-@pytest.mark.parametrize('flags', [NOHOST, INET_ATON | INET_PTON])
+@pytest.mark.parametrize('flags', [
+    NOHOST,
+    INET_ATON | INET_PTON,
+    INET_ATON | INET_PTON_STRICT,
+    INET_PTON | INET_PTON_STRICT,
+    ZEROFILL | INET_PTON_STRICT,
+])
 def test_invalid_ipaddress_flags_are_rejected(flags):
     with pytest.raises(ValueError):
         IPAddress('1.2.3.4', flags=flags)

--- a/netaddr/tests/ip/test_ip_v4.py
+++ b/netaddr/tests/ip/test_ip_v4.py
@@ -5,7 +5,7 @@ import sys
 
 import pytest
 
-from netaddr import IPAddress, IPNetwork, INET_ATON, INET_PTON, spanning_cidr, AddrFormatError, ZEROFILL, Z, P, NOHOST
+from netaddr import IPAddress, IPNetwork, INET_ATON, INET_PTON, INET_PTON_STRICT, spanning_cidr, AddrFormatError, ZEROFILL, Z, P, NOHOST
 
 
 def test_ipaddress_v4():
@@ -366,6 +366,22 @@ def test_ipaddress_inet_pton_constructor_v4():
         IPAddress('10.0.1', flags=INET_PTON)
 
     assert IPAddress('10.0.0.1', flags=INET_PTON) == IPAddress('10.0.0.1')
+
+
+@pytest.mark.parametrize('address', [
+    '1',
+    '1.1',
+    '1.1.1',
+    '0x7f.0.0.1',
+    '01.0.0.1',
+])
+def test_ipaddress_inet_pton_strict_rejects_invalid_addresses(address):
+    with pytest.raises(AddrFormatError):
+        IPAddress(address, flags=INET_PTON_STRICT)
+
+
+def test_ipaddress_inet_pton_strict_accepts_good_address():
+    assert IPAddress('127.0.0.1', flags=INET_PTON_STRICT).value == 2130706433
 
 
 def test_ipaddress_constructor_zero_filled_octets_v4():


### PR DESCRIPTION
It's like INET_PTON but it predictably, on all operating systems, rejects leading zeros.

The intention is to make it the default in the next major release (after deprecating the current behavior, which will be implemented separately).