### PR TITLE
Document some deprecations

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -20,6 +20,22 @@ Deprecated:
 * Deprecate Python 3.7 support.
 * Deprecate abbreviated CIDR format support in :class:`IPNetwork`
   (``implicit_prefix=True``).
+* Deprecate accepting leading zeros when parsing IPv4 addresses in :data:`INET_PTON` mode
+  (it's been allowed on some platforms).
+
+  If you need to allow and discard leading zeros use the :data:`ZEROFILL` flag.
+
+  This change will implicit conversions from ``str`` in all relevant contexts. If you need
+  to control the IPv4 parsing mode construct :class:`IPAddress` objects explicitly.
+* Deprecate parsing IPv4 addresses permissively (``inet_aton()``-like) by default.
+
+  :data:`INET_PTON` will become the default mode.
+
+  If you need to be permissive and parse using ``inet_aton()`` semantics use the
+  :data:`INET_ATON` flag.
+
+  This change will implicit conversions from ``str`` in all relevant contexts. If you need
+  to control the IPv4 parsing mode construct :class:`IPAddress` objects explicitly.
 
 Other:
 

--- a/docs/source/api.rst
+++ b/docs/source/api.rst
@@ -49,6 +49,9 @@ The following constants are used by the various *flags* arguments on netaddr cla
 
    See the :meth:`IPAddress.__init__` documentation for details.
 
+   .. versionchanged:: NEXT_NETADDR_VERSION
+        This parsing mode will become stricter in the future and it will reject leading zeros.
+
 .. data:: netaddr.INET_ATON
 
     Use ``inet_aton()`` semantics when parsing IPv4.

--- a/netaddr/ip/__init__.py
+++ b/netaddr/ip/__init__.py
@@ -284,6 +284,10 @@ class IPAddress(BaseIP):
 
               >>> IPAddress('010.020.030.040', flags=INET_PTON | ZEROFILL)
               IPAddress('10.20.30.40')
+
+        .. versionchanged:: NEXT_NETADDR_VERSION
+            The default IPv4 parsing mode is scheduled to become :data:`INET_PTON` in the next
+            major release.
         """
         super(IPAddress, self).__init__()
 


### PR DESCRIPTION
Give the users heads up about some things that are about to change.

This is all to make the library more difficult to misuse, the legacy IPv4 parsing is pretty error prone and I'd expect it to not be widely used.