### PR TITLE
Add IPAddress.is_ipv4_private_use

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,7 @@ Added:
 
 * Add an :data:`INET_ATON` flag to explicitly request ``inet_aton()`` IPv4 parsing semantics
   from :class:`IPAddress`.
+* Add an :meth:`IPAddress.is_ipv4_private_use` convenience method.
 
 Fixed:
 

--- a/netaddr/ip/__init__.py
+++ b/netaddr/ip/__init__.py
@@ -160,7 +160,7 @@ class BaseIP(object):
             3330, 4193, 3879 and 2365.
         """
         if self._module.version == 4:
-            for cidr in IPV4_PRIVATE:
+            for cidr in IPV4_PRIVATEISH:
                 if self in cidr:
                     return True
         elif self._module.version == 6:
@@ -729,6 +729,22 @@ class IPAddress(BaseIP):
         if not self.is_ipv4_mapped():
             return self
         return self.ipv4()
+
+    def is_ipv4_private_use(self):
+        """
+        Returns ``True`` if this address is an IPv4 private-use address as defined in
+        :rfc:`1918`.
+
+        The private-use address blocks:
+
+        * ``10.0.0.0/8``
+        * ``172.16.0.0/12``
+        * ``192.168.0.0/16``
+
+        .. versionadded:: NEXT_NETADDR_VERSION
+        """
+        return self._module.version == 4 and any(self in cidr for cidr in IPV4_PRIVATE_USE)
+
 
 class IPListMixin(object):
     """
@@ -1990,13 +2006,17 @@ def all_matching_cidrs(ip, cidrs):
 #-----------------------------------------------------------------------------
 IPV4_LOOPBACK  = IPNetwork('127.0.0.0/8')    #   Loopback addresses (RFC 990)
 
-IPV4_PRIVATE = (
+IPV4_PRIVATE_USE = [
     IPNetwork('10.0.0.0/8'),        #   Class A private network local communication (RFC 1918)
-    IPNetwork('100.64.0.0/10'),     #   Carrier grade NAT (RFC 6598)
     IPNetwork('172.16.0.0/12'),     #   Private network - local communication (RFC 1918)
+    IPNetwork('192.168.0.0/16'),    #  Class B private network local communication (RFC 1918)
+]
+
+IPV4_PRIVATEISH = (
+    *IPV4_PRIVATE_USE,
+    IPNetwork('100.64.0.0/10'),     #   Carrier grade NAT (RFC 6598)
     IPNetwork('192.0.0.0/24'),      #   IANA IPv4 Special Purpose Address Registry (RFC 5736)
     # protocol assignments
-    IPNetwork('192.168.0.0/16'),    #  Class B private network local communication (RFC 1918)
     
     # benchmarking
     IPNetwork('198.18.0.0/15'),     #  Testing of inter-network communications between subnets (RFC 2544)

--- a/netaddr/ip/__init__.py
+++ b/netaddr/ip/__init__.py
@@ -2012,8 +2012,7 @@ IPV4_PRIVATE_USE = [
     IPNetwork('192.168.0.0/16'),    #  Class B private network local communication (RFC 1918)
 ]
 
-IPV4_PRIVATEISH = (
-    *IPV4_PRIVATE_USE,
+IPV4_PRIVATEISH = tuple(IPV4_PRIVATE_USE) + (
     IPNetwork('100.64.0.0/10'),     #   Carrier grade NAT (RFC 6598)
     IPNetwork('192.0.0.0/24'),      #   IANA IPv4 Special Purpose Address Registry (RFC 5736)
     # protocol assignments

--- a/netaddr/tests/ip/test_ip_categories.py
+++ b/netaddr/tests/ip/test_ip_categories.py
@@ -12,6 +12,7 @@ reserved = 1 << 5
 ipv4_mapped = 1 << 6
 hostmask = 1 << 7
 netmask = 1 << 8
+ipv4_private_use = 1 << 9
 
 flags = {
     'unicast': unicast,
@@ -23,6 +24,7 @@ flags = {
     'ipv4_mapped': ipv4_mapped,
     'hostmask': hostmask,
     'netmask': netmask,
+    'ipv4_private_use': ipv4_private_use,
 }
 
 
@@ -31,12 +33,12 @@ flags = {
     ['0.0.0.0', reserved | hostmask | netmask | unicast],
     ['0.0.1.255', hostmask | reserved | unicast | hostmask],
     ['0.255.255.255', reserved | hostmask | unicast],
-    ['10.0.0.1', private | unicast],
+    ['10.0.0.1', ipv4_private_use | private | unicast],
     ['62.125.24.5', unicast],
     ['100.64.0.0', private | unicast],
     ['127.0.0.0', reserved | loopback | unicast | reserved],
     ['127.0.0.1', loopback | reserved | unicast],
-    ['172.24.0.1', private | unicast],
+    ['172.24.0.1', ipv4_private_use | private | unicast],
     ['127.255.255.255', reserved | hostmask | loopback | unicast],
     ['169.254.0.0', link_local | private | unicast],
     ['192.0.0.0', netmask | private | unicast],
@@ -53,7 +55,7 @@ flags = {
     ['192.52.193.0', unicast],
     ['192.88.99.0', reserved | unicast],
     ['192.88.99.255', reserved | unicast],
-    ['192.168.0.1', private | unicast],
+    ['192.168.0.1', ipv4_private_use | private | unicast],
     ['192.175.48.0', unicast],
     ['198.18.0.0', private | unicast],
     ['198.19.255.255', private | unicast],


### PR DESCRIPTION
I plan to deprecate the existing is_private method and we neeed some
better replacements for it. This is one, there'll be more to complement
it.

"ipv4" in the name to make it clear it's IPv4-only.