### PR TITLE
Implement IPAddress.is_ipv6_unique_local

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -13,6 +13,7 @@ Added:
 * Add an :meth:`IPAddress.is_ipv4_private_use` convenience method.
 * Add an :meth:`IPAddress.is_global` convenience method to allow determining if an address is
   considered globally reachable.
+* Add an :meth:`IPAddress.is_ipv6_unique_local` convenience method.
 
 Fixed:
 

--- a/netaddr/ip/__init__.py
+++ b/netaddr/ip/__init__.py
@@ -164,7 +164,7 @@ class BaseIP(object):
                 if self in cidr:
                     return True
         elif self._module.version == 6:
-            for cidr in IPV6_PRIVATE:
+            for cidr in IPV6_PRIVATEISH:
                 if self in cidr:
                     return True
 
@@ -786,6 +786,17 @@ class IPAddress(BaseIP):
         .. versionadded:: NEXT_NETADDR_VERSION
         """
         return self._module.version == 4 and any(self in cidr for cidr in IPV4_PRIVATE_USE)
+
+    def is_ipv6_unique_local(self):
+        """
+        Returns ``True`` if this address is an IPv6 unique local address as defined in
+        :rfc:`4193` and listed in |iana_special_ipv6|.
+
+        The IPv6 unique local address block: ``fc00::/7``.
+
+        .. versionadded:: NEXT_NETADDR_VERSION
+        """
+        return self._module.version == 6 and self in IPV6_UNIQUE_LOCAL
 
 
 class IPListMixin(object):
@@ -2112,8 +2123,10 @@ IPV4_NOT_GLOBALLY_REACHABLE_EXCEPTIONS = [
 #-----------------------------------------------------------------------------
 IPV6_LOOPBACK = IPNetwork('::1/128')
 
-IPV6_PRIVATE = (
-    IPNetwork('fc00::/7'),  #   Unique Local Addresses (ULA)
+IPV6_UNIQUE_LOCAL = IPNetwork('fc00::/7')
+
+IPV6_PRIVATEISH = (
+    IPV6_UNIQUE_LOCAL,
     IPNetwork('fec0::/10'), #   Site Local Addresses (deprecated - RFC 3879)
 )
 

--- a/netaddr/tests/ip/test_ip_categories.py
+++ b/netaddr/tests/ip/test_ip_categories.py
@@ -14,6 +14,7 @@ hostmask = 1 << 7
 netmask = 1 << 8
 ipv4_private_use = 1 << 9
 global_ = 1 << 10
+ipv6_unique_local = 1 << 11
 
 flags = {
     'unicast': unicast,
@@ -27,6 +28,7 @@ flags = {
     'netmask': netmask,
     'ipv4_private_use': ipv4_private_use,
     'global': global_,
+    'ipv6_unique_local': ipv6_unique_local,
 }
 
 
@@ -88,7 +90,7 @@ flags = {
     ['2001:db8::', unicast],
     ['2002::', unicast],
     ['2620:4f:8000::', global_ | unicast],
-    ['fc00::1', private | unicast],
+    ['fc00::1', ipv6_unique_local | private | unicast],
     ['fe80::1', private | unicast | link_local],
     ['ff00::1', global_ | reserved | multicast],
 ])


### PR DESCRIPTION
I plan to deprecate the is_private methods and this will serve as a partial replacement for IPv6 addresses.