### PR TITLE
Prioritize non-deprecated importlib.resources API

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -6,6 +6,10 @@ NEXT_NETADDR_VERSION
 
 Date: YYYY-MM-DD
 
+Fixed:
+
+* Get rid of some warnings
+
 ---------------
 Release: 0.10.0
 ---------------

--- a/netaddr/compat.py
+++ b/netaddr/compat.py
@@ -92,8 +92,9 @@ try:
 except ImportError:
     import importlib_resources as _importlib_resources
 
-try:
-    _open_binary = _importlib_resources.open_binary
-except AttributeError:
+
+if hasattr(_importlib_resources, 'files'):
     def _open_binary(pkg, res):
         return _importlib_resources.files(pkg).joinpath(res).open('rb')
+else:
+    _open_binary = _importlib_resources.open_binary


### PR DESCRIPTION
This allows us to get rid of this warning:

    (...) DeprecationWarning: open_binary is deprecated. Use files() instead (...)