### PR TITLE
Deprecate the one-letter flags

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,11 @@ Fixed:
 
 * Get rid of some warnings
 
+Deprecated:
+
+* Deprecate the flag shorthands: ``N``, ``P`` and ``Z``. Use :data:`NOHOST`, :data:`INET_PTON`
+  and :data:`ZEROFILL` instead.
+
 ---------------
 Release: 0.10.0
 ---------------


### PR DESCRIPTION
They're quite opaque and if someone truly needs them I think their code will benefit from the extra verbosity.