### PR TITLE
Remove some private API references from the documentation

### DIFF
--- a/netaddr/ip/sets.py
+++ b/netaddr/ip/sets.py
@@ -98,7 +98,7 @@ class IPSet(object):
             subnets or ranges.
 
         :param flags: decides which rules are applied to the interpretation
-            of the addr value. See the netaddr.core namespace documentation
+            of the addr value. See the :class:`IPAddress` documentation
             for supported constant values.
 
         """
@@ -274,7 +274,7 @@ class IPSet(object):
             an IPRange object.
 
         :param flags: decides which rules are applied to the interpretation
-            of the addr value. See the netaddr.core namespace documentation
+            of the addr value. See the :class:`IPAddress` documentation
             for supported constant values.
 
         """
@@ -310,7 +310,7 @@ class IPSet(object):
         :param addr: An IP address or subnet, or an IPRange.
 
         :param flags: decides which rules are applied to the interpretation
-            of the addr value. See the netaddr.core namespace documentation
+            of the addr value. See the :class:`IPAddress` documentation
             for supported constant values.
 
         """
@@ -385,7 +385,7 @@ class IPSet(object):
         :param iterable: an iterable containing IP addresses, subnets or ranges.
 
         :param flags: decides which rules are applied to the interpretation
-            of the addr value. See the netaddr.core namespace documentation
+            of the addr value. See the :class:`IPAddress` documentation
             for supported constant values.
 
         """

--- a/netaddr/strategy/ipv4.py
+++ b/netaddr/strategy/ipv4.py
@@ -84,7 +84,7 @@ def valid_str(addr, flags=0):
 
     :param flags: decides which rules are applied to the interpretation of the
         addr value. Supported constants are INET_PTON and ZEROFILL. See the
-        netaddr.core docs for details.
+        :class:`IPAddress` documentation for details.
 
     :return: ``True`` if IPv4 address is valid, ``False`` otherwise.
     """
@@ -113,7 +113,7 @@ def str_to_int(addr, flags=0):
 
     :param flags: decides which rules are applied to the interpretation of the
         addr value. Supported constants are INET_PTON and ZEROFILL. See the
-        netaddr.core docs for details.
+        :class:`IPAddress` documentation for details.
 
     :return: The equivalent unsigned integer for a given IPv4 address.
     """


### PR DESCRIPTION
End-users are supposed to import things from the top level netaddr namespace, not from the submodules.