### PR TITLE
Mention a valid_ipv4-related deprecation

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,7 +18,7 @@ Deprecated:
   top-level ``netaddr`` namespace is supported, everything else is considered private.
 
   This has already been the case but we can use a reminder.
-* Deprecate permissive-by-default IPv4 parsing in :function:`valid_ipv4`. The ``inet_pton()``
+* Deprecate permissive-by-default IPv4 parsing in :func:`valid_ipv4`. The ``inet_pton()``
   semantics (with leading zeros always disallowed) will become the default. Use :data:`INET_ATON`
   and/or :data:`ZEROFILL` flags if you need the legacy behavior.
 

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -18,6 +18,9 @@ Deprecated:
   top-level ``netaddr`` namespace is supported, everything else is considered private.
 
   This has already been the case but we can use a reminder.
+* Deprecate permissive-by-default IPv4 parsing in :function:`valid_ipv4`. The ``inet_pton()``
+  semantics (with leading zeros always disallowed) will become the default. Use :data:`INET_ATON`
+  and/or :data:`ZEROFILL` flags if you need the legacy behavior.
 
 ---------------
 Release: 0.10.0

--- a/netaddr/strategy/ipv4.py
+++ b/netaddr/strategy/ipv4.py
@@ -86,6 +86,10 @@ def valid_str(addr, flags=0):
         addr value. Supported constants are INET_PTON and ZEROFILL. See the
         :class:`IPAddress` documentation for details.
 
+    .. versionchanged:: NEXT_NETADDR_VERSION
+        ``flags`` is scheduled to default to :data:`INET_PTON` instead of :data:`INET_ATON`
+        in the future.
+
     :return: ``True`` if IPv4 address is valid, ``False`` otherwise.
     """
     if addr == '':


### PR DESCRIPTION
I forgot about this function when I applied [1].

[1] 86f1e3d95618 ("Document some deprecations (#320)")