### PR TITLE
Produce only one source distribution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ dist: clean doc
 	@echo 'building netaddr release'
 	python setup.py develop
 	@echo 'building source distributions'
-	python setup.py sdist --formats=gztar,zip
+	python setup.py sdist
 	@echo 'building wheel package'
 	pip install --upgrade pip
 	pip install wheel


### PR DESCRIPTION
PyPI doesn't accept multiple source distributions (anymore?), let's stick to one.