### PR TITLE
Stop (re)building the documentation in "make dist"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ clean:
 	find . -name '*.pyc' -exec rm -f {} ';'
 	find . -name '*.pyo' -exec rm -f {} ';'
 
-dist: clean doc
+dist: clean
 	@echo 'building netaddr release'
 	python setup.py develop
 	@echo 'building source distributions'


### PR DESCRIPTION
We don't upload the documentation manually anywhere anyway, ReadTheDocs picks it up directly from GitHub.