### PR TITLE
Stop depending on importlib_resources

### DIFF
--- a/netaddr/compat.py
+++ b/netaddr/compat.py
@@ -87,14 +87,11 @@ else:
     raise RuntimeError(
         'this module only supports Python 2.4.x or higher (including 3.x)!')
 
-try:
-    from importlib import resources as _importlib_resources
-except ImportError:
-    import importlib_resources as _importlib_resources
 
+import importlib.resources
 
-if hasattr(_importlib_resources, 'files'):
+if hasattr(importlib.resources, 'files'):
     def _open_binary(pkg, res):
-        return _importlib_resources.files(pkg).joinpath(res).open('rb')
+        return importlib.resources.files(pkg).joinpath(res).open('rb')
 else:
-    _open_binary = _importlib_resources.open_binary
+    _open_binary = importlib.resources.open_binary

--- a/setup.py
+++ b/setup.py
@@ -137,7 +137,6 @@ def main():
             .strip()
             .strip('\'"')
         ),
-        install_requires=['importlib-resources;python_version<"3.7"'],
     )
 
     setup(**setup_options)


### PR DESCRIPTION
We only support Python 3.7+ now and it's built in.