### PR TITLE
dist: include THANKS

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -6,6 +6,7 @@ include LICENSE
 include Makefile
 include MANIFEST.in
 include release.py
+include THANKS
 
 recursive-include docs/source *.rst *.py
 graft tutorials


### PR DESCRIPTION
Otherwise docs generation from dist tarball fails with:

netaddr-0.10.1/docs/source/contributors.rst:5: CRITICAL: Problems with "include" directive path:
InputError: [Errno 2] No such file or directory: '../THANKS'.