### PR TITLE
Set up initial Mypy configuration for type checking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ push_tags:
 	@echo 'syncing tags'
 	git push --tags
 
-ci: lint test_with_junitxml
+ci: mypy lint test_with_junitxml
 
 lint:
 	ruff format --check
@@ -71,3 +71,7 @@ test: clean
 test_with_junitxml: clean
 	@echo 'running test suite with JUnit XML output'
 	py.test -vv --junitxml=junit.xml
+
+.PHONY: mypy
+mypy:
+	mypy netaddr

--- a/netaddr/eui/ieee.py
+++ b/netaddr/eui/ieee.py
@@ -34,16 +34,17 @@ More details can be found at the following URLs :-
 
 import os.path as _path
 import csv as _csv
+from typing import Dict, Tuple
 
 from netaddr.compat import _open_binary
 from netaddr.core import Subscriber, Publisher
 
 
 #: OUI index lookup dictionary.
-OUI_INDEX = {}
+OUI_INDEX: Dict[int, Tuple[int, int]] = {}
 
 #: IAB index lookup dictionary.
-IAB_INDEX = {}
+IAB_INDEX: Dict[int, Tuple[int, int]] = {}
 
 
 class FileIndexer(Subscriber):

--- a/netaddr/ip/iana.py
+++ b/netaddr/ip/iana.py
@@ -30,6 +30,7 @@ More details can be found at the following URLs :-
 """
 
 import sys as _sys
+from typing import Any, Dict, Tuple, TypedDict, Union
 from xml.sax import make_parser, handler
 
 from netaddr.core import Publisher, Subscriber
@@ -37,8 +38,16 @@ from netaddr.ip import IPAddress, IPNetwork, IPRange, cidr_abbrev_to_verbose
 from netaddr.compat import _open_binary
 
 
+class IanaInfoType(TypedDict):
+    # TODO: Make the types more precise, get rid of Any
+    IPv4: Dict[IPNetwork, Any]
+    IPv6: Dict[IPNetwork, Any]
+    IPv6_unicast: Dict[IPNetwork, Any]
+    multicast: Dict[Union[IPRange, IPAddress], Any]
+
+
 #: Topic based lookup dictionary for IANA information.
-IANA_INFO = {
+IANA_INFO: IanaInfoType = {
     'IPv4': {},
     'IPv6': {},
     'IPv6_unicast': {},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -111,3 +111,10 @@ line-length = 100
 
 [tool.ruff.format]
 quote-style = 'single'
+
+[tool.mypy]
+# Only temporarily false until the codebase passes strict checks
+strict = false
+exclude = [
+    "/tests/",
+]

--- a/requirements.in
+++ b/requirements.in
@@ -2,6 +2,8 @@
 coverage<7
 pluggy<1.3
 
+ipython
+mypy
 pytest>=2.4.2
 pytest-cov
 ruff


### PR DESCRIPTION
The plan is to have full static type/type hint coverage in the codebase, this is a first step towards that goal.

Some module-level variables needed types right away so that's included in this patch.