### PR TITLE
Remove some Python 2-related artifacts

### DIFF
--- a/netaddr/tests/eui/test_eui.py
+++ b/netaddr/tests/eui/test_eui.py
@@ -1,8 +1,5 @@
-import sys
 import pickle
 import random
-
-import pytest
 
 from netaddr import (
     EUI,
@@ -38,8 +35,7 @@ def test_mac_address_numerical_operations():
     assert mac.bin == '0b1101101110111010010010101010011111101'
 
 
-@pytest.mark.skipif(sys.version_info < (3,), reason='requires python 3.x')
-def test_eui_oct_format_py3():
+def test_eui_oct_format():
     assert oct(EUI('00-1B-77-49-54-FD')) == '0o1556722252375'
 
 

--- a/netaddr/tests/eui/test_ieee_parsers.py
+++ b/netaddr/tests/eui/test_ieee_parsers.py
@@ -1,16 +1,11 @@
 import contextlib
-import sys
-
-import pytest
+from io import StringIO
 
 from netaddr.compat import _open_binary
 from netaddr.eui.ieee import OUIIndexParser, IABIndexParser, FileIndexer
 
 
-@pytest.mark.skipif(sys.version_info < (3,), reason='requires python 3.x')
-def test_oui_parser_py3():
-    from io import StringIO
-
+def test_oui_parser():
     outfile = StringIO()
     with contextlib.closing(_open_binary(__package__, 'sample_oui.txt')) as infile:
         iab_parser = OUIIndexParser(infile)
@@ -19,10 +14,7 @@ def test_oui_parser_py3():
     assert outfile.getvalue() == '51966,1,138\n'
 
 
-@pytest.mark.skipif(sys.version_info < (3,), reason='requires python 3.x')
-def test_iab_parser_py3():
-    from io import StringIO
-
+def test_iab_parser():
     outfile = StringIO()
     with contextlib.closing(_open_binary(__package__, 'sample_iab.txt')) as infile:
         iab_parser = IABIndexParser(infile)

--- a/netaddr/tests/ip/test_ip_v4.py
+++ b/netaddr/tests/ip/test_ip_v4.py
@@ -1,7 +1,6 @@
 import pickle
 import types
 import random
-import sys
 
 import pytest
 
@@ -27,8 +26,7 @@ def test_ipaddress_v4():
     assert ip.format() == '192.0.2.1'
     assert int(ip) == 3221225985
     assert hex(ip) == '0xc0000201'
-    if sys.version_info[0] > 2:
-        assert bytes(ip) == b'\xc0\x00\x02\x01'
+    assert bytes(ip) == b'\xc0\x00\x02\x01'
     assert ip.bin == '0b11000000000000000000001000000001'
     assert ip.bits() == '11000000.00000000.00000010.00000001'
     assert ip.words == (192, 0, 2, 1)
@@ -443,8 +441,7 @@ def test_ipaddress_hex_format():
     assert hex(IPAddress(0xFFFFFFFF)) == '0xffffffff'
 
 
-@pytest.mark.skipif('sys.version_info < (3,)', reason='python 3.x behaviour')
-def test_ipaddress_oct_format_py3():
+def test_ipaddress_oct_format():
     assert oct(IPAddress(0xFFFFFFFF)) == '0o37777777777'
     assert oct(IPAddress(0)) == '0o0'
 

--- a/netaddr/tests/ip/test_ip_v6.py
+++ b/netaddr/tests/ip/test_ip_v6.py
@@ -1,5 +1,4 @@
 import pickle
-import sys
 import pytest
 from netaddr import IPAddress, IPNetwork
 
@@ -12,8 +11,7 @@ def test_ipaddress_v6():
     assert ip.format() == 'fe80::dead:beef'
     assert int(ip) == 338288524927261089654018896845083623151
     assert hex(ip) == '0xfe8000000000000000000000deadbeef'
-    if sys.version_info[0] > 2:
-        assert bytes(ip) == b'\xfe\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xad\xbe\xef'
+    assert bytes(ip) == b'\xfe\x80\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xde\xad\xbe\xef'
     assert (
         ip.bin
         == '0b11111110100000000000000000000000000000000000000000000000000000000000000000000000000000000000000011011110101011011011111011101111'

--- a/netaddr/tests/strategy/test_eui48_strategy.py
+++ b/netaddr/tests/strategy/test_eui48_strategy.py
@@ -1,7 +1,3 @@
-import sys
-
-import pytest
-
 from netaddr.strategy import eui48
 
 
@@ -10,6 +6,7 @@ def test_strategy_eui48():
     i = 64945841971
     t = (0x0, 0x0F, 0x1F, 0x12, 0xE7, 0x33)
     s = '00-0F-1F-12-E7-33'
+    p = b'\x00\x0f\x1f\x12\xe73'
 
     assert eui48.bits_to_int(b) == i
     assert eui48.int_to_bits(i) == b
@@ -21,11 +18,6 @@ def test_strategy_eui48():
     assert eui48.words_to_int(t) == i
     assert eui48.words_to_int(list(t)) == i
 
-
-@pytest.mark.skipif(sys.version_info < (3,), reason='requires python 3.x')
-def test_strategy_eui48_py3():
-    i = 64945841971
-    p = b'\x00\x0f\x1f\x12\xe73'
     assert eui48.int_to_packed(i) == p
     assert eui48.packed_to_int(p) == i
 

--- a/netaddr/tests/strategy/test_ipv4_strategy.py
+++ b/netaddr/tests/strategy/test_ipv4_strategy.py
@@ -1,5 +1,3 @@
-import sys
-
 import pytest
 
 from netaddr import INET_PTON, AddrFormatError
@@ -12,6 +10,7 @@ def test_strategy_ipv4():
     t = (192, 0, 2, 1)
     s = '192.0.2.1'
     bin_val = '0b11000000000000000000001000000001'
+    p = b'\xc0\x00\x02\x01'
 
     assert ipv4.bits_to_int(b) == i
     assert ipv4.int_to_bits(i) == b
@@ -23,12 +22,6 @@ def test_strategy_ipv4():
     assert ipv4.words_to_int(t) == i
     assert ipv4.words_to_int(list(t)) == i
     assert ipv4.valid_bin(bin_val)
-
-
-@pytest.mark.skipif(sys.version_info < (3,), reason='requires python 3.x')
-def test_strategy_ipv4_py3():
-    i = 3221225985
-    p = b'\xc0\x00\x02\x01'
     assert ipv4.int_to_packed(i) == p
     assert ipv4.packed_to_int(p) == i
 

--- a/netaddr/tests/strategy/test_ipv6_strategy.py
+++ b/netaddr/tests/strategy/test_ipv6_strategy.py
@@ -136,7 +136,7 @@ def test_strategy_ipv6_mapped_and_compatible_ipv4_string_formatting():
     # So this is strange. Even though on Windows we get decimal notation in a lot of the addresses above,
     # in case of 0.0.0.0 we get hex instead. Worth investigating, putting
     # the conditional assert here for now to make this visible.
-    if platform.system() == 'Windows' and platform.python_implementation() == 'PyPy':
+    if platform.system() == 'Windows':
         assert ipv6.int_to_str(0xFFFF00000000) == '::ffff:0:0'
     else:
         assert ipv6.int_to_str(0xFFFF00000000) == '::ffff:0.0.0.0'

--- a/netaddr/tests/strategy/test_ipv6_strategy.py
+++ b/netaddr/tests/strategy/test_ipv6_strategy.py
@@ -1,5 +1,4 @@
 import platform
-import sys
 
 import pytest
 
@@ -12,6 +11,7 @@ def test_strategy_ipv6():
     i = 4294967294
     t = (0, 0, 0, 0, 0, 0, 0xFFFF, 0xFFFE)
     s = '::255.255.255.254'
+    p = b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\xff\xfe'
 
     assert ipv6.bits_to_int(b) == i
     assert ipv6.int_to_bits(i) == b
@@ -23,11 +23,6 @@ def test_strategy_ipv6():
     assert ipv6.words_to_int(t) == i
     assert ipv6.words_to_int(list(t)) == i
 
-
-@pytest.mark.skipif(sys.version_info < (3,), reason='requires python 3.x')
-def test_strategy_ipv6_py3():
-    i = 4294967294
-    p = b'\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\x00\xff\xff\xff\xfe'
     assert ipv6.int_to_packed(i) == p
     assert ipv6.packed_to_int(p) == 4294967294
 
@@ -139,12 +134,9 @@ def test_strategy_ipv6_mapped_and_compatible_ipv4_string_formatting():
     assert ipv6.int_to_str(0xFFFF000000) == '::ff:ff00:0'
     assert ipv6.int_to_str(0x1FFFF00000000) == '::1:ffff:0:0'
     # So this is strange. Even though on Windows we get decimal notation in a lot of the addresses above,
-    # in case of 0.0.0.0 we get hex instead, unless it's Python 2, then we get decimal... unless it's
-    # actually PyPy Python 2, then we always get hex (again, only on Windows). Worth investigating, putting
+    # in case of 0.0.0.0 we get hex instead. Worth investigating, putting
     # the conditional assert here for now to make this visible.
-    if platform.system() == 'Windows' and (
-        platform.python_version() >= '3.0' or platform.python_implementation() == 'PyPy'
-    ):
+    if platform.system() == 'Windows' and platform.python_implementation() == 'PyPy':
         assert ipv6.int_to_str(0xFFFF00000000) == '::ffff:0:0'
     else:
         assert ipv6.int_to_str(0xFFFF00000000) == '::ffff:0.0.0.0'


### PR DESCRIPTION
No longer necessary or relevant, Python 2 support has been dropped.