### PR TITLE
Reject IPv4 leading zeros in INET_PTON parsing mode

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -10,6 +10,17 @@ Removed:
 
 * Drop support for Python versions lower than 3.7.
 
+Changed:
+
+* Stop accepting leading zeros when parsing IPv4 addresses in :data:`INET_PTON` mode
+  (it's been allowed on some platforms).
+
+  If you need to allow and discard leading zeros use the :data:`ZEROFILL` flag.
+
+  This change will implicit conversions from ``str`` in all relevant contexts. If you need
+  to control the IPv4 parsing mode construct :class:`IPAddress` objects explicitly.
+
+
 ---------------
 Release: 0.10.1
 ---------------

--- a/netaddr/strategy/ipv4.py
+++ b/netaddr/strategy/ipv4.py
@@ -121,8 +121,11 @@ def str_to_int(addr, flags=0):
 
     :return: The equivalent unsigned integer for a given IPv4 address.
     """
+    error = AddrFormatError('%r is not a valid IPv4 address string!' % (addr,))
     if flags & ZEROFILL:
         addr = '.'.join(['%d' % int(i) for i in addr.split('.')])
+    elif flags & INET_PTON and any(len(p) > 1 and p.startswith('0') for p in addr.split('.')):
+        raise error
 
     try:
         if flags & INET_PTON:
@@ -130,7 +133,7 @@ def str_to_int(addr, flags=0):
         else:
             return _struct.unpack('>I', _inet_aton(addr))[0]
     except Exception:
-        raise AddrFormatError('%r is not a valid IPv4 address string!' % (addr,))
+        raise error
 
 
 def int_to_str(int_val, dialect=None):

--- a/netaddr/tests/ip/test_ip_v4.py
+++ b/netaddr/tests/ip/test_ip_v4.py
@@ -372,6 +372,10 @@ def test_ipaddress_inet_aton_constructor_v4():
         '10',
         '10.1',
         '10.0.1',
+        '010.0.0.1',
+        '10.01.0.1',
+        '10.0.00.1',
+        '10.0.1.01',
     ],
 )
 def test_ipaddress_inet_pton_constructor_v4_rejects_invalid_input(address):

--- a/netaddr/tests/ip/test_platform_osx.py
+++ b/netaddr/tests/ip/test_platform_osx.py
@@ -2,7 +2,7 @@ import platform
 
 import pytest
 
-from netaddr import iprange_to_cidrs, IPNetwork, IPAddress, INET_PTON, AddrFormatError
+from netaddr import iprange_to_cidrs, IPNetwork
 from netaddr.strategy.ipv6 import int_to_str
 
 
@@ -73,9 +73,7 @@ def test_ip_behaviour_osx():
         IPNetwork('::255.255.255.254/128'),
     ]
 
-    #   inet_pton has to be different on Mac OSX *sigh*...
-    assert IPAddress('010.000.000.001', flags=INET_PTON) == IPAddress('10.0.0.1')
-    # ...but at least Apple changed inet_ntop in Mac OS 10.15 (Catalina) so it's compatible with Linux
+    # At least Apple changed inet_ntop in Mac OS 10.15 (Catalina) so it's compatible with Linux
     if platform.mac_ver()[0] >= '10.15':
         assert int_to_str(0xFFFF) == '::ffff'
     else:
@@ -148,9 +146,5 @@ def test_ip_behaviour_non_osx():
         IPNetwork('::255.255.255.252/127'),
         IPNetwork('::255.255.255.254/128'),
     ]
-
-    #   Sadly, inet_pton cannot help us here ...
-    with pytest.raises(AddrFormatError):
-        IPAddress('010.000.000.001', flags=INET_PTON)
 
     assert int_to_str(0xFFFF) == '::ffff'


### PR DESCRIPTION
Deprecated a while ago as source of potential tricky problems.