### PR TITLE
Make IPv4 parsing more restrictive by default

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -21,7 +21,15 @@ Changed:
 
   This change will implicit conversions from ``str`` in all relevant contexts. If you need
   to control the IPv4 parsing mode construct :class:`IPAddress` objects explicitly.
+* Stop parsing IPv4 addresses permissively (``inet_aton()``-like) by default.
 
+  :data:`INET_PTON` is the default mode.
+
+  If you need to be permissive and parse using ``inet_aton()`` semantics use the
+  :data:`INET_ATON` flag.
+
+  This change will affect implicit conversions from ``str`` in all relevant contexts. If you
+  need to control the IPv4 parsing mode construct :class:`IPAddress` objects explicitly.
 
 ---------------
 Release: 0.10.1

--- a/docs/source/tutorial_03.rst
+++ b/docs/source/tutorial_03.rst
@@ -145,7 +145,7 @@ More exotic IPSets
 True
 >>> IPAddress("0.0.0.0") in bigone
 True
->>> IPAddress("255.255.255") in bigone
+>>> IPAddress("255.255.255.0") in bigone
 True
 >>> IPNetwork("10.0.0.0/24") in bigone
 True

--- a/netaddr/ip/__init__.py
+++ b/netaddr/ip/__init__.py
@@ -296,38 +296,37 @@ class IPAddress(BaseIP):
 
             Allowed flag values:
 
-            * The default (``0``) or :data:`INET_ATON`. Follows `inet_aton semantics
+            * :data:`INET_ATON`. Follows `inet_aton semantics
               <https://www.netmeister.org/blog/inet_aton.html>`_ and allows all kinds of
               weird-looking addresses to be parsed. For example:
 
-              >>> IPAddress('1')
+              >>> IPAddress('1', flags=INET_ATON)
               IPAddress('0.0.0.1')
-              >>> IPAddress('1.0xf')
+              >>> IPAddress('1.0xf', flags=INET_ATON)
               IPAddress('1.0.0.15')
-              >>> IPAddress('010.020.030.040')
+              >>> IPAddress('010.020.030.040', flags=INET_ATON)
               IPAddress('8.16.24.32')
 
-            * ``INET_ATON | ZEROFILL`` or :data:`ZEROFILL` – like the default, except leading zeros are discarded:
+            * ``INET_ATON | ZEROFILL`` or :data:`ZEROFILL` – like ``INET_ATON``, except leading zeros are discarded:
 
               >>> IPAddress('010', flags=INET_ATON | ZEROFILL)
               IPAddress('0.0.0.10')
 
-            * :data:`INET_PTON` – requires four decimal octets:
+            * The default (``0``) or :data:`INET_PTON` – requires four decimal octets:
 
               >>> IPAddress('10.0.0.1', flags=INET_PTON)
               IPAddress('10.0.0.1')
 
               Leading zeros may be ignored or rejected, depending on the platform.
 
-            * ``INET_PTON | ZEROFILL`` – like :data:`INET_PTON`, except leading zeros are
-              discarded:
+            * ``INET_PTON | ZEROFILL`` – like the default :data:`INET_PTON`, except leading
+              zeros are discarded:
 
               >>> IPAddress('010.020.030.040', flags=INET_PTON | ZEROFILL)
               IPAddress('10.20.30.40')
 
-        .. versionchanged:: 0.10.0
-            The default IPv4 parsing mode is scheduled to become :data:`INET_PTON` in the next
-            major release.
+        .. versionchanged:: NEXT_NETADDR_VERSION
+            Changed the default IPv4 parsing mode from :data:`INET_ATON` to :data:`INET_PTON`.
         """
         super(IPAddress, self).__init__()
 

--- a/netaddr/strategy/ipv4.py
+++ b/netaddr/strategy/ipv4.py
@@ -19,7 +19,7 @@ else:
     #   All other cases, use all functions from the socket module.
     from socket import inet_pton as _inet_pton, AF_INET
 
-from netaddr.core import AddrFormatError, ZEROFILL, INET_PTON
+from netaddr.core import AddrFormatError, ZEROFILL, INET_ATON, INET_PTON
 
 from netaddr.strategy import (
     valid_words as _valid_words,
@@ -122,13 +122,14 @@ def str_to_int(addr, flags=0):
     :return: The equivalent unsigned integer for a given IPv4 address.
     """
     error = AddrFormatError('%r is not a valid IPv4 address string!' % (addr,))
+    pton_mode = flags & INET_PTON or not flags & INET_ATON
     if flags & ZEROFILL:
         addr = '.'.join(['%d' % int(i) for i in addr.split('.')])
-    elif flags & INET_PTON and any(len(p) > 1 and p.startswith('0') for p in addr.split('.')):
+    elif pton_mode and any(len(p) > 1 and p.startswith('0') for p in addr.split('.')):
         raise error
 
     try:
-        if flags & INET_PTON:
+        if pton_mode:
             return _struct.unpack('>I', _inet_pton(AF_INET, addr))[0]
         else:
             return _struct.unpack('>I', _inet_aton(addr))[0]

--- a/netaddr/tests/ip/test_ip_sets.py
+++ b/netaddr/tests/ip/test_ip_sets.py
@@ -150,7 +150,7 @@ def test_ipset_membership_largest():
 
     assert IPAddress('10.0.0.1') in ipset
     assert IPAddress('0.0.0.0') in ipset
-    assert IPAddress('255.255.255') in ipset
+    assert IPAddress('255.255.255.0') in ipset
     assert IPNetwork('10.0.0.0/24') in ipset
     assert IPAddress('::1') not in ipset
 

--- a/netaddr/tests/ip/test_ip_v4.py
+++ b/netaddr/tests/ip/test_ip_v4.py
@@ -347,19 +347,16 @@ def test_ipaddress_integer_constructor_v6():
 
 
 def test_ipaddress_inet_aton_constructor_v4():
-    assert IPAddress('0x7f.0x1') == IPAddress('127.0.0.1')
-    assert IPAddress('0x7f.0x0.0x0.0x1') == IPAddress('127.0.0.1')
-    assert IPAddress('0177.01') == IPAddress('127.0.0.1')
-    assert IPAddress('0x7f.0.01') == IPAddress('127.0.0.1')
+    assert IPAddress('0x7f.0x1', flags=INET_ATON) == IPAddress('127.0.0.1')
+    assert IPAddress('0x7f.0x0.0x0.0x1', flags=INET_ATON) == IPAddress('127.0.0.1')
+    assert IPAddress('0177.01', flags=INET_ATON) == IPAddress('127.0.0.1')
+    assert IPAddress('0x7f.0.01', flags=INET_ATON) == IPAddress('127.0.0.1')
 
     # Partial addresses - pretty weird, but valid ...
-    assert IPAddress('127') == IPAddress('0.0.0.127')
-    assert IPAddress('127') == IPAddress('0.0.0.127')
-    assert IPAddress('127.1') == IPAddress('127.0.0.1')
-    assert IPAddress('127.0.1') == IPAddress('127.0.0.1')
-
-    # Verify explicit INET_ATON is the same as the current default
-    assert IPAddress('127', flags=INET_ATON) == IPAddress('127')
+    assert IPAddress('127', flags=INET_ATON) == IPAddress('0.0.0.127')
+    assert IPAddress('127', flags=INET_ATON) == IPAddress('0.0.0.127')
+    assert IPAddress('127.1', flags=INET_ATON) == IPAddress('127.0.0.1')
+    assert IPAddress('127.0.1', flags=INET_ATON) == IPAddress('127.0.0.1')
 
 
 @pytest.mark.parametrize(
@@ -380,17 +377,21 @@ def test_ipaddress_inet_pton_constructor_v4_rejects_invalid_input(address):
     with pytest.raises(AddrFormatError):
         IPAddress(address, flags=INET_PTON)
 
+    with pytest.raises(AddrFormatError):
+        IPAddress(address)
+
 
 def test_ipaddress_inet_pton_constructor_v4_accepts_valid_input():
     assert IPAddress('10.0.0.1', flags=INET_PTON) == IPAddress('10.0.0.1')
 
 
 def test_ipaddress_constructor_zero_filled_octets_v4():
-    assert IPAddress('010.000.000.001') == IPAddress('8.0.0.1')
-    assert IPAddress('010.000.000.001', flags=ZEROFILL) == IPAddress('10.0.0.1')
-    assert IPAddress('010.000.001', flags=ZEROFILL) == IPAddress('10.0.0.1')
-    # Verify explicit INET_ATON is the same as the current default
+    assert IPAddress('010.000.000.001', flags=INET_ATON) == IPAddress('8.0.0.1')
     assert IPAddress('010.000.000.001', flags=INET_ATON | ZEROFILL) == IPAddress('10.0.0.1')
+    assert IPAddress('010.000.001', flags=INET_ATON | ZEROFILL) == IPAddress('10.0.0.1')
+
+    with pytest.raises(AddrFormatError):
+        assert IPAddress('010.000.001', flags=ZEROFILL)
 
     with pytest.raises(AddrFormatError):
         assert IPAddress('010.000.001', flags=INET_PTON | ZEROFILL)

--- a/netaddr/tests/strategy/test_ipv4_strategy.py
+++ b/netaddr/tests/strategy/test_ipv4_strategy.py
@@ -1,6 +1,6 @@
 import pytest
 
-from netaddr import INET_PTON, AddrFormatError
+from netaddr import INET_ATON, INET_PTON, AddrFormatError
 from netaddr.strategy import ipv4
 
 
@@ -32,13 +32,13 @@ def test_strategy_inet_aton_behaviour():
     # is also the most widely used by system software used in software today,
     # so netaddr supports this behaviour by default.
 
-    assert ipv4.str_to_int('127') == 127
-    assert ipv4.str_to_int('0x7f') == 127
-    assert ipv4.str_to_int('0177') == 127
-    assert ipv4.str_to_int('127.1') == 2130706433
-    assert ipv4.str_to_int('0x7f.1') == 2130706433
-    assert ipv4.str_to_int('0177.1') == 2130706433
-    assert ipv4.str_to_int('127.0.0.1') == 2130706433
+    assert ipv4.str_to_int('127', flags=INET_ATON) == 127
+    assert ipv4.str_to_int('0x7f', flags=INET_ATON) == 127
+    assert ipv4.str_to_int('0177', flags=INET_ATON) == 127
+    assert ipv4.str_to_int('127.1', flags=INET_ATON) == 2130706433
+    assert ipv4.str_to_int('0x7f.1', flags=INET_ATON) == 2130706433
+    assert ipv4.str_to_int('0177.1', flags=INET_ATON) == 2130706433
+    assert ipv4.str_to_int('127.0.0.1', flags=INET_ATON) == 2130706433
 
 
 def test_strategy_inet_pton_behaviour():


### PR DESCRIPTION
Planned some time ago, INET_ATON has some big footguns – can be requested explicitly if someone really needs it.