### PR TITLE
Return False when passing empty strings to valid_{ipv4,ipv6}

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -31,6 +31,11 @@ Changed:
   This change will affect implicit conversions from ``str`` in all relevant contexts. If you
   need to control the IPv4 parsing mode construct :class:`IPAddress` objects explicitly.
 
+Fixed:
+
+* Return ``False`` instead of raising :exc:`AddrFormatError` when an empty string is passed
+  to :func:`valid_ipv4` or :func:`valid_ipv6`.
+
 ---------------
 Release: 0.10.1
 ---------------

--- a/netaddr/strategy/ipv4.py
+++ b/netaddr/strategy/ipv4.py
@@ -91,10 +91,10 @@ def valid_str(addr, flags=0):
         in the future.
 
     :return: ``True`` if IPv4 address is valid, ``False`` otherwise.
-    """
-    if addr == '':
-        raise AddrFormatError('Empty strings are not supported!')
 
+    .. versionchanged:: NEXT_NETADDR_VERSION
+        Returns ``False`` instead of raising :exc:`AddrFormatError` for empty strings.
+    """
     validity = True
 
     if flags & ZEROFILL:

--- a/netaddr/strategy/ipv6.py
+++ b/netaddr/strategy/ipv6.py
@@ -120,10 +120,10 @@ def valid_str(addr, flags=0):
         addr value. Future use - currently has no effect.
 
     :return: ``True`` if IPv6 address is valid, ``False`` otherwise.
-    """
-    if addr == '':
-        raise AddrFormatError('Empty strings are not supported!')
 
+    .. versionchanged:: NEXT_NETADDR_VERSION
+        Returns ``False`` instead of raising :exc:`AddrFormatError` for empty strings.
+    """
     try:
         _inet_pton(AF_INET6, addr)
     except:

--- a/netaddr/tests/strategy/test_ipv4_strategy.py
+++ b/netaddr/tests/strategy/test_ipv4_strategy.py
@@ -64,3 +64,15 @@ def test_strategy_inet_pton_behaviour():
         ipv4.str_to_int('0177.1', flags=INET_PTON)
 
     assert ipv4.str_to_int('127.0.0.1', flags=INET_PTON) == 2130706433
+
+
+@pytest.mark.parametrize(
+    ('address', 'flags', 'valid'),
+    [
+        ['', 0, False],
+        ['192', INET_ATON, True],
+        ['127.0.0.1', 0, True],
+    ],
+)
+def test_valid_str(address, flags, valid):
+    assert ipv4.valid_str(address, flags) is valid

--- a/netaddr/tests/strategy/test_ipv6_strategy.py
+++ b/netaddr/tests/strategy/test_ipv6_strategy.py
@@ -84,6 +84,7 @@ def test_strategy_ipv6_valid_str(str_value):
 @pytest.mark.parametrize(
     'str_value',
     (
+        '',
         'g:h:i:j:k:l:m:n',  # bad chars.
         '0:0:0:0:0:0:0:0:0',  # too long,
         #   Unexpected types.
@@ -96,11 +97,6 @@ def test_strategy_ipv6_valid_str(str_value):
 )
 def test_strategy_ipv6_is_not_valid_str(str_value):
     assert not ipv6.valid_str(str_value)
-
-
-def test_strategy_ipv6_valid_str_exception_on_empty_string():
-    with pytest.raises(AddrFormatError):
-        ipv6.valid_str('')
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
I think it makes more sense this way. An empty strings is clearly an invalid IP address.

Fixes: https://github.com/netaddr/netaddr/issues/155