### PR TITLE
Make ipv4.valid_str (AKA valid_ipv6) match IPAddress strictness

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -32,6 +32,7 @@ Changed:
 
   This change will affect implicit conversions from ``str`` in all relevant contexts. If you
   need to control the IPv4 parsing mode construct :class:`IPAddress` objects explicitly.
+* Apply the two changes above to :func:`valid_ipv4` as well.
 
 Fixed:
 

--- a/netaddr/strategy/ipv4.py
+++ b/netaddr/strategy/ipv4.py
@@ -95,20 +95,11 @@ def valid_str(addr, flags=0):
     .. versionchanged:: NEXT_NETADDR_VERSION
         Returns ``False`` instead of raising :exc:`AddrFormatError` for empty strings.
     """
-    validity = True
-
-    if flags & ZEROFILL:
-        addr = '.'.join(['%d' % int(i) for i in addr.split('.')])
-
     try:
-        if flags & INET_PTON:
-            _inet_pton(AF_INET, addr)
-        else:
-            _inet_aton(addr)
-    except Exception:
-        validity = False
-
-    return validity
+        str_to_int(addr, flags)
+    except AddrFormatError:
+        return False
+    return True
 
 
 def str_to_int(addr, flags=0):

--- a/netaddr/tests/strategy/test_ipv4_strategy.py
+++ b/netaddr/tests/strategy/test_ipv4_strategy.py
@@ -70,6 +70,7 @@ def test_strategy_inet_pton_behaviour():
     ('address', 'flags', 'valid'),
     [
         ['', 0, False],
+        ['192', 0, False],
         ['192', INET_ATON, True],
         ['127.0.0.1', 0, True],
     ],


### PR DESCRIPTION
I applied two changes recently that made ipv4.str_to_int/IPAddress stricter[1][2], it only make sense that valid_str matches that new semantics.

It's achieved with better code reuse, which is (almost) always welcome.

[1] 95bd1f46109e ("Make IPv4 parsing more restrictive by default (#359)")
[2] 3644adaa7599 ("Reject IPv4 leading zeros in INET_PTON parsing mode (#356)")