### PR TITLE
Fix dialect handling in EUI during copy-construction

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -38,6 +38,7 @@ Fixed:
 
 * Return ``False`` instead of raising :exc:`AddrFormatError` when an empty string is passed
   to :func:`valid_ipv4` or :func:`valid_ipv6`.
+* Fix handling of ``dialect`` provided to :class:`EUI` during copy-construction.
 
 ---------------
 Release: 0.10.1

--- a/netaddr/eui/__init__.py
+++ b/netaddr/eui/__init__.py
@@ -352,7 +352,7 @@ class EUI(BaseIdentifier):
                 raise ValueError('cannot switch EUI versions using ' 'copy constructor!')
             self._module = addr._module
             self._value = addr._value
-            self.dialect = addr.dialect
+            self.dialect = dialect or addr.dialect
             return
 
         if version is not None:

--- a/netaddr/tests/eui/test_eui.py
+++ b/netaddr/tests/eui/test_eui.py
@@ -96,6 +96,12 @@ def test_eui_dialect_property_assignment():
     assert str(mac) == '001b77:4954fd'
 
 
+def test_eui_copy_constructor_dialect_support():
+    mac = EUI('00-1B-77-49-54-FD')
+    copy = EUI(mac, dialect=mac_unix_expanded)
+    assert str(copy) == '00:1b:77:49:54:fd'
+
+
 def test_eui_format():
     mac = EUI('00-1B-77-49-54-FD')
     assert mac.format() == '00-1B-77-49-54-FD'


### PR DESCRIPTION
It was simply ignored before.

Fixes: https://github.com/netaddr/netaddr/issues/250