### PR TITLE
Add changelog URL to package metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -94,6 +94,7 @@ dynamic = ["version"]
 [project.urls]
 Download = "https://pypi.org/project/netaddr/"
 Repository = "https://github.com/drkjam/netaddr/"
+Changelog = "https://netaddr.readthedocs.io/en/latest/changes.html"
 
 [project.scripts]
 netaddr = "netaddr.cli:main"


### PR DESCRIPTION
These links will be visible on the package's PyPI page:

> ![image](https://github.com/netaddr/netaddr/assets/137616/76b548ce-5af6-4ad1-9aa6-f44b4a2cacbb)

And also tools like Renovate bot use this to provide direct access to the changelog for a dependency update.
