### PR TITLE
valid_ipN: Return False when non string value is given

### DIFF
--- a/netaddr/strategy/ipv4.py
+++ b/netaddr/strategy/ipv4.py
@@ -95,6 +95,8 @@ def valid_str(addr, flags=0):
     .. versionchanged:: 1.0.0
         Returns ``False`` instead of raising :exc:`AddrFormatError` for empty strings.
     """
+    if not isinstance(addr, str):
+        return False
     try:
         str_to_int(addr, flags)
     except AddrFormatError:

--- a/netaddr/strategy/ipv6.py
+++ b/netaddr/strategy/ipv6.py
@@ -124,6 +124,8 @@ def valid_str(addr, flags=0):
     .. versionchanged:: 1.0.0
         Returns ``False`` instead of raising :exc:`AddrFormatError` for empty strings.
     """
+    if not isinstance(addr, str):
+        return False
     try:
         _inet_pton(AF_INET6, addr)
     except:


### PR DESCRIPTION
... to restore the previous behavior, instead of raising AttributeError from internal logic. Note that this change may not be required for v6 method but that's being added as safe guard for future change.

Closes: #368