### PR TITLE
Improve the exceptions raised by fbsocket's inet_pton

### DIFF
--- a/netaddr/fbsocket.py
+++ b/netaddr/fbsocket.py
@@ -112,7 +112,7 @@ def _inet_pton_af_inet(ip_string):
     """
     # TODO: optimise this ... use inet_aton with mods if available ...
     if isinstance(ip_string, str):
-        invalid_addr = ValueError('illegal IP address string %r' % ip_string)
+        invalid_addr = OSError('illegal IP address string %r' % ip_string)
         #   Support for hexadecimal and octal octets.
         tokens = ip_string.split('.')
 
@@ -134,7 +134,7 @@ def _inet_pton_af_inet(ip_string):
         else:
             raise invalid_addr
 
-    raise ValueError('argument should be a string, not %s' % type(ip_string))
+    raise TypeError(f'inet_pton() argument 2 must be str, not {type(ip_string)}')
 
 
 def inet_pton(af, ip_string):
@@ -146,12 +146,12 @@ def inet_pton(af, ip_string):
         #   IPv4.
         return _inet_pton_af_inet(ip_string)
     elif af == AF_INET6:
-        invalid_addr = ValueError('illegal IP address string %r' % ip_string)
+        invalid_addr = OSError('illegal IP address string %r' % ip_string)
         #   IPv6.
         values = []
 
         if not isinstance(ip_string, str):
-            raise invalid_addr
+            raise TypeError(f'inet_pton() argument 2 must be str, not {type(ip_string)}')
 
         if 'x' in ip_string:
             #   Don't accept hextets with the 0x prefix.

--- a/netaddr/tests/ip/test_socket_module_fallback.py
+++ b/netaddr/tests/ip/test_socket_module_fallback.py
@@ -1,6 +1,6 @@
 import pytest
 
-from netaddr.fbsocket import inet_ntop, inet_pton, inet_ntoa, AF_INET6
+from netaddr.fbsocket import inet_ntop, inet_pton, inet_ntoa, AF_INET, AF_INET6
 
 
 @pytest.mark.parametrize(
@@ -35,6 +35,17 @@ def test_inet_ntoa_ipv4_exceptions():
         inet_ntoa('\x00')
 
 
+def test_inet_pton_ipv4_exceptions():
+    with pytest.raises(OSError):
+        inet_pton(AF_INET, '::0x07f')
+
+    with pytest.raises(TypeError):
+        inet_pton(AF_INET, 1)
+
+
 def test_inet_pton_ipv6_exceptions():
-    with pytest.raises(ValueError):
+    with pytest.raises(OSError):
         inet_pton(AF_INET6, '::0x07f')
+
+    with pytest.raises(TypeError):
+        inet_pton(AF_INET6, 1)


### PR DESCRIPTION
The original socket.inet_pton raises TypeError on non-str passed as an address and OSError in case of an invalid address.

This will help with more precise exception handling (we use socket.inet_pton and fbsocket.inet_pton interchangeably in a couple of places).