### PR TITLE
valid_ipN: Raise TypeError for non string value

### DIFF
--- a/netaddr/strategy/ipv4.py
+++ b/netaddr/strategy/ipv4.py
@@ -95,6 +95,8 @@ def valid_str(addr, flags=0):
     .. versionchanged:: 1.0.0
         Returns ``False`` instead of raising :exc:`AddrFormatError` for empty strings.
     """
+    if not isinstance(addr, str):
+        raise TypeError('Invalid type: %s' % type(addr))
     try:
         str_to_int(addr, flags)
     except AddrFormatError:

--- a/netaddr/strategy/ipv6.py
+++ b/netaddr/strategy/ipv6.py
@@ -124,6 +124,8 @@ def valid_str(addr, flags=0):
     .. versionchanged:: 1.0.0
         Returns ``False`` instead of raising :exc:`AddrFormatError` for empty strings.
     """
+    if not isinstance(addr, str):
+        raise TypeError('Invalid type: %s' % type(addr))
     try:
         _inet_pton(AF_INET6, addr)
     except OSError:

--- a/netaddr/tests/strategy/test_ipv4_strategy.py
+++ b/netaddr/tests/strategy/test_ipv4_strategy.py
@@ -77,3 +77,19 @@ def test_strategy_inet_pton_behaviour():
 )
 def test_valid_str(address, flags, valid):
     assert ipv4.valid_str(address, flags) is valid
+
+
+@pytest.mark.parametrize(
+    'str_value',
+    (
+        [],
+        (),
+        {},
+        True,
+        False,
+        192,
+    ),
+)
+def test_valid_str_unexpected_types(str_value):
+    with pytest.raises(TypeError):
+        ipv4.valid_str(str_value)

--- a/netaddr/tests/strategy/test_ipv6_strategy.py
+++ b/netaddr/tests/strategy/test_ipv6_strategy.py
@@ -94,6 +94,22 @@ def test_strategy_ipv6_is_not_valid_str(str_value):
 
 
 @pytest.mark.parametrize(
+    'str_value',
+    (
+        [],
+        (),
+        {},
+        True,
+        False,
+        192,
+    ),
+)
+def test_valid_str_unexpected_types(str_value):
+    with pytest.raises(TypeError):
+        ipv6.valid_str(str_value)
+
+
+@pytest.mark.parametrize(
     ('long_form', 'short_form'),
     (
         ('FEDC:BA98:7654:3210:FEDC:BA98:7654:3210', 'fedc:ba98:7654:3210:fedc:ba98:7654:3210'),


### PR DESCRIPTION
This fixes the inconsistent behavior of valid_ipv4 and valid_ipv6 for non-string value, and makes both these methods raise TypeError. These returned False in <1.0.0 but that behavior was not intended.