### PR TITLE
Update github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
           pypy3.7, pypy3.8, pypy3.9, pypy3.10,
         ]
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -32,4 +32,4 @@ jobs:
       run: |
         make ci
     - name: Report coverage to Codecov
-      uses: codecov/codecov-action@v1
+      uses: codecov/codecov-action@v4


### PR DESCRIPTION
... to resolve the following warnings.

```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v2, actions/setup-python@v4, codecov/codecov-action@v1. For more information see: ...
The following actions uses node12 which is deprecated and will be forced to run on node16: actions/checkout@v2,
codecov/codecov-action@v1. For more info: ...
```