### PR TITLE
IPNetwork: Allow partial addresses (again)

### DIFF
--- a/netaddr/tests/ip/test_ip_v4.py
+++ b/netaddr/tests/ip/test_ip_v4.py
@@ -355,6 +355,14 @@ def test_ipnetwork_bad_string_constructor():
         IPNetwork('foo')
 
 
+def test_ipnetwork_expand_v4():
+    with pytest.raises(AddrFormatError):
+        IPNetwork('10/8')
+    assert IPNetwork('10/8', expand=True) == IPNetwork('10.0.0.0/8')
+    assert IPNetwork('10.20/16', expand=True) == IPNetwork('10.20.0.0/16')
+    assert IPNetwork('10.20.30/24', expand=True) == IPNetwork('10.20.30.0/24')
+
+
 def test_ipaddress_netmask_v4():
     assert IPAddress('0.0.0.0').netmask_bits() == 0
     assert IPAddress('128.0.0.0').netmask_bits() == 1


### PR DESCRIPTION
This introduces the new expand argument to IPNetwork class, so that users can retain the previous behavior of netaddr < 1.0.0 optionally.

```
>>> import netaddr
>>> netaddr.IPNetwork('10/8')
Traceback (most recent call last):
  File "/home/tkajinam/git/python/netaddr/netaddr/strategy/ipv4.py", line 126, in str_to_int
    packed = _inet_pton(AF_INET, addr)
             ^^^^^^^^^^^^^^^^^^^^^^^^^
OSError: illegal IP address string passed to inet_pton

...

During handling of the above exception, another exception occurred:
    
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/home/tkajinam/git/python/netaddr/netaddr/ip/__init__.py", line 1035, in __init__
    raise AddrFormatError('invalid IPNetwork %s' % (addr,))
netaddr.core.AddrFormatError: invalid IPNetwork 10/8
>>> netaddr.IPNetwork('10/8', partial=True)
IPNetwork('10.0.0.0/8')
```