### PR TITLE
Fix IPv6 parsing with ZEROFILL enabled

### DIFF
--- a/netaddr/strategy/ipv4.py
+++ b/netaddr/strategy/ipv4.py
@@ -115,6 +115,8 @@ def str_to_int(addr, flags=0):
     :return: The equivalent unsigned integer for a given IPv4 address.
     """
     error = AddrFormatError('%r is not a valid IPv4 address string!' % (addr,))
+    if ':' in addr:
+        raise error
     pton_mode = flags & INET_PTON or not flags & INET_ATON
     if flags & ZEROFILL:
         addr = '.'.join(['%d' % int(i) for i in addr.split('.')])

--- a/netaddr/tests/ip/test_ip_v6.py
+++ b/netaddr/tests/ip/test_ip_v6.py
@@ -1,6 +1,6 @@
 import pickle
 import pytest
-from netaddr import IPAddress, IPNetwork
+from netaddr import IPAddress, IPNetwork, ZEROFILL
 
 
 def test_ipaddress_v6():
@@ -174,3 +174,7 @@ def test_rfc6164_subnets():
     assert IPNetwork('1234::/128').broadcast is None
     assert list(IPNetwork('1234::/128')) == [IPAddress('1234::')]
     assert list(IPNetwork('1234::/128').iter_hosts()) == [IPAddress('1234::')]
+
+
+def test_ipaddress_ignores_zerofill_when_parsing_ipv6():
+    assert IPAddress('fe80::', flags=ZEROFILL)

--- a/netaddr/tests/strategy/test_ipv4_strategy.py
+++ b/netaddr/tests/strategy/test_ipv4_strategy.py
@@ -1,6 +1,6 @@
 import pytest
 
-from netaddr import INET_ATON, INET_PTON, AddrFormatError
+from netaddr import INET_ATON, INET_PTON, AddrFormatError, ZEROFILL
 from netaddr.strategy import ipv4
 
 
@@ -37,6 +37,11 @@ def test_strategy_inet_aton_behaviour():
     assert ipv4.str_to_int('0x7f.1', flags=INET_ATON) == 2130706433
     assert ipv4.str_to_int('0177.1', flags=INET_ATON) == 2130706433
     assert ipv4.str_to_int('127.0.0.1', flags=INET_ATON) == 2130706433
+
+
+def test_str_to_int_correctly_rejects_ipv6_with_zerofill():
+    with pytest.raises(AddrFormatError):
+        ipv4.str_to_int('fe80::', flags=ZEROFILL)
 
 
 def test_strategy_inet_pton_behaviour():


### PR DESCRIPTION
It was a regression, affected IPAddress.

Fixes: d39b7d124280 ("Handle IP parsing errors more precisely")
Resolves: https://github.com/netaddr/netaddr/issues/383