### PR TITLE
Drop Python 3.7 from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
         # so pin this to 20.04.
         os: [ubuntu-20.04, macos-latest, windows-latest]
         python-version: [
-          3.7, 3.8, 3.9, "3.10", 3.11,
-          pypy3.7, pypy3.8, pypy3.9, pypy3.10,
+          3.8, 3.9, "3.10", 3.11,
+          pypy3.8, pypy3.9, pypy3.10,
         ]
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
It seems that there's no longer Python 3.7 available for the test runs in CI[1]:

    Run actions/setup-python@v5
    Installed versions
      Version 3.7 was not found in the local cache
      Error: The version '3.7' with architecture 'arm64' was not found for macOS 14.4.1.
      The list of all available versions can be found here: https://raw.githubusercontent.com/actions/python-versions/main/versions-manifest.json

This change is not dropping support for Python 3.7 yet, we just can't test with it anymore using GH Actions.

[1] https://github.com/netaddr/netaddr/actions/runs/9165981748/job/25200497622