### PR TITLE
Include Python 3.12 in the CI configuration

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
         # so pin this to 20.04.
         os: [ubuntu-20.04, macos-latest, windows-latest]
         python-version: [
-          3.8, 3.9, "3.10", 3.11,
+          3.8, 3.9, "3.10", 3.11, 3.12,
           pypy3.8, pypy3.9, pypy3.10,
         ]
     steps:


### PR DESCRIPTION
We support Python 3.12, better test with it too.